### PR TITLE
Simplify startup and improve contract actions

### DIFF
--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -45,7 +45,6 @@ public partial class App : Application
                 services.AddSingleton<ContractEditViewModel>();
                 services.AddSingleton<PartyEditViewModel>();
                 services.AddSingleton<SettingsService>();
-                services.AddSingleton<LandingViewModel>();
                 services.AddSingleton<IJobFactory, QuartzJobFactory>();
                 services.AddSingleton(provider =>
                 {
@@ -67,14 +66,15 @@ public partial class App : Application
         await scheduler.Start();
 
         var settings = scope.ServiceProvider.GetRequiredService<SettingsService>();
-        var landingVm = scope.ServiceProvider.GetRequiredService<LandingViewModel>();
-        var landingWindow = new LandingWindow { DataContext = landingVm };
-        landingWindow.Show();
+        var mainVm = scope.ServiceProvider.GetRequiredService<MainViewModel>();
+        await mainVm.Contracts.LoadAsync();
+        var mainWindow = new MainWindow { DataContext = mainVm };
+        mainWindow.Show();
 
         if (string.IsNullOrWhiteSpace(settings.CompanyName))
         {
             var settingsVm = new SettingsViewModel(settings);
-            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = landingWindow };
+            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = mainWindow };
             settingsWindow.ShowDialog();
         }
     }


### PR DESCRIPTION
## Summary
- Launch the main window with `MainViewModel` directly on startup, bypassing the landing screen.
- Convert contract list toolbar commands to `AsyncRelayCommand` and provide user feedback for new, import, and export actions.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ff58494c832985849b6dc1fa42a7