### PR TITLE
Fix binding and CsvExporter reference errors

### DIFF
--- a/PaperTrail.App/PaperTrail.App.csproj
+++ b/PaperTrail.App/PaperTrail.App.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Quartz" Version="3.15.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-	<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-	<PackageReference Include="Uno.UI" Version="5.6.99" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PaperTrail.Core\PaperTrail.Core.csproj" />

--- a/PaperTrail.App/Services/ExportService.cs
+++ b/PaperTrail.App/Services/ExportService.cs
@@ -1,5 +1,6 @@
 using PaperTrail.Core.DTO;
 using PaperTrail.Core.Repositories;
+using PaperTrail.Core.Services;
 
 namespace PaperTrail.App.Services;
 


### PR DESCRIPTION
## Summary
- remove Uno.UI package causing XAML binding errors
- include Core Services namespace in ExportService

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50868e7088329b106277f127c55c9