### PR TITLE
Fix DateOnly conversion setup in EF Core

### DIFF
--- a/PaperTrail.Core/Data/AppDbContext.cs
+++ b/PaperTrail.Core/Data/AppDbContext.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PaperTrail.Core.Models;
 
 namespace PaperTrail.Core.Data;
@@ -30,13 +29,9 @@ public class AppDbContext : DbContext
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
-        var converter = new ValueConverter<DateOnly, DateTime>(
-            d => d.ToDateTime(TimeOnly.MinValue),
-            d => DateOnly.FromDateTime(d));
-
         configurationBuilder
             .Properties<DateOnly>()
-            .HaveConversion(converter);
+            .HaveConversion<DateOnlyConverter>();
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/PaperTrail.Core/Data/DateOnlyConverter.cs
+++ b/PaperTrail.Core/Data/DateOnlyConverter.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace PaperTrail.Core.Data;
+
+public class DateOnlyConverter : ValueConverter<DateOnly, DateTime>
+{
+    public DateOnlyConverter()
+        : base(d => d.ToDateTime(TimeOnly.MinValue), d => DateOnly.FromDateTime(d))
+    {
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `DateOnlyConverter` for `DateOnly` to `DateTime` conversions
- Use the converter type in `AppDbContext` conventions configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c53578aac88329bb1dfc74bad14e74