### PR TITLE
Fix command bindings for landing and settings windows

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -5,7 +5,7 @@
     <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button Content="Manage Contracts"
                 Command="{Binding OpenMainCommand}"
-                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                 Margin="0,0,0,10" Width="200" />
         <Button Content="Settings" Command="{Binding OpenSettingsCommand}" Width="200" />
     </StackPanel>

--- a/PaperTrail.App/SettingsWindow.xaml
+++ b/PaperTrail.App/SettingsWindow.xaml
@@ -13,7 +13,7 @@
         <TextBox Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}" />
         <Button Content="Save"
                 Command="{Binding SaveCommand}"
-                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                 HorizontalAlignment="Right" Margin="0,10,0,0" />
     </StackPanel>
 </Window>


### PR DESCRIPTION
## Summary
- ensure Landing and Settings windows use x:Type when binding to parent window

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c536fe0da08329a9b34dbb397e3c12