### PR TITLE
Fix command parameter binding on landing window

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -1,12 +1,15 @@
 <Window x:Class="PaperTrail.App.LandingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Name="LandingWindow"
         Title="PaperTrail Contract Tracker" Height="200" Width="300">
     <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button Content="Manage Contracts"
                 Command="{Binding OpenMainCommand}"
-                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                CommandParameter="{Binding ElementName=LandingWindow}"
                 Margin="0,0,0,10" Width="200" />
-        <Button Content="Settings" Command="{Binding OpenSettingsCommand}" Width="200" />
+        <Button Content="Settings"
+                Command="{Binding OpenSettingsCommand}"
+                Width="200" />
     </StackPanel>
 </Window>


### PR DESCRIPTION
## Summary
- fix landing page command parameter binding to avoid markup extension errors

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5382307688329a044930769684311