### PR TITLE
Ensure Landing window commands bind correctly

### DIFF
--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -17,6 +17,7 @@ namespace PaperTrail.App;
 public partial class App : Application
 {
     private IHost? _host;
+    public IServiceProvider Services => _host?.Services ?? throw new InvalidOperationException("Host not initialized");
 
     protected override async void OnStartup(StartupEventArgs e)
     {
@@ -41,6 +42,7 @@ public partial class App : Application
                 services.AddSingleton<HashService>();
                 services.AddTransient<ReminderEngine>();
                 services.AddSingleton<MainViewModel>();
+                services.AddSingleton<LandingViewModel>();
                 services.AddSingleton<ContractListViewModel>();
                 services.AddSingleton<ContractEditViewModel>();
                 services.AddSingleton<PartyEditViewModel>();
@@ -65,17 +67,7 @@ public partial class App : Application
         await scheduler.ScheduleJob(job, trigger);
         await scheduler.Start();
 
-        var settings = scope.ServiceProvider.GetRequiredService<SettingsService>();
-        var mainVm = scope.ServiceProvider.GetRequiredService<MainViewModel>();
-        await mainVm.Contracts.LoadAsync();
-        var mainWindow = new MainWindow { DataContext = mainVm };
-        mainWindow.Show();
-
-        if (string.IsNullOrWhiteSpace(settings.CompanyName))
-        {
-            var settingsVm = new SettingsViewModel(settings);
-            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = mainWindow };
-            settingsWindow.ShowDialog();
-        }
+        var landingWindow = new LandingWindow();
+        landingWindow.Show();
     }
 }

--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -6,7 +6,7 @@
     <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button Content="Manage Contracts"
                 Command="{Binding OpenMainCommand}"
-                CommandParameter="{Binding ElementName=LandingWindow}"
+                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                 Margin="0,0,0,10" Width="200" />
         <Button Content="Settings"
                 Command="{Binding OpenSettingsCommand}"

--- a/PaperTrail.App/LandingWindow.xaml.cs
+++ b/PaperTrail.App/LandingWindow.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using PaperTrail.App.ViewModels;
 
 namespace PaperTrail.App;
 
@@ -7,5 +9,6 @@ public partial class LandingWindow : Window
     public LandingWindow()
     {
         InitializeComponent();
+        DataContext = ((App)Application.Current).Services.GetRequiredService<LandingViewModel>();
     }
 }

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -29,6 +29,13 @@ public class LandingViewModel : ObservableObject
         var main = new MainWindow { DataContext = _mainViewModel };
         main.Show();
         window?.Close();
+
+        if (string.IsNullOrWhiteSpace(_settings.CompanyName))
+        {
+            var settingsVm = new SettingsViewModel(_settings);
+            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = main };
+            settingsWindow.ShowDialog();
+        }
     }
 
     private void OpenSettings()


### PR DESCRIPTION
## Summary
- Pass the window reference via `RelativeSource` and resolve `LandingViewModel` through DI
- Expose application services and register `LandingViewModel` for dependency injection
- Launch the landing window at startup and show settings dialog when needed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c539fe4700832982352d71ad9823b7