### PR TITLE
Ensure Landing window commands bind correctly

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -6,7 +6,7 @@
     <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button Content="Manage Contracts"
                 Command="{Binding OpenMainCommand}"
-                CommandParameter="{Binding ElementName=LandingWindow}"
+                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                 Margin="0,0,0,10" Width="200" />
         <Button Content="Settings"
                 Command="{Binding OpenSettingsCommand}"


### PR DESCRIPTION
## Summary
- Revert previous startup and view-model wiring changes
- Pass window reference via `RelativeSource` in `LandingWindow.xaml` to bind Manage Contracts command without code-behind updates

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c539fe4700832982352d71ad9823b7