### PR TITLE
feat: enhance contract editor with validation and commands

### DIFF
--- a/PaperTrail.App/ContractWindow.xaml
+++ b/PaperTrail.App/ContractWindow.xaml
@@ -2,6 +2,12 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:PaperTrail.App.Views"
-        Title="Contract" Height="250" Width="300">
+        Title="{Binding Title, StringFormat=Edit Contract -- {0}}" Height="600" Width="800"
+        Closing="Window_Closing">
+    <Window.InputBindings>
+        <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}" />
+    </Window.InputBindings>
     <views:ContractEditView />
 </Window>

--- a/PaperTrail.App/ContractWindow.xaml.cs
+++ b/PaperTrail.App/ContractWindow.xaml.cs
@@ -8,4 +8,12 @@ public partial class ContractWindow : Window
     {
         InitializeComponent();
     }
+
+    private void Window_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        if (DataContext is ViewModels.ContractEditViewModel vm)
+        {
+            e.Cancel = !vm.ConfirmClose();
+        }
+    }
 }

--- a/PaperTrail.App/Converters/EnumToItemsSourceConverter.cs
+++ b/PaperTrail.App/Converters/EnumToItemsSourceConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PaperTrail.App.Converters;
+
+public class EnumToItemsSourceConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter is Type enumType && enumType.IsEnum)
+        {
+            return Enum.GetValues(enumType);
+        }
+        if (value is Type type && type.IsEnum)
+        {
+            return Enum.GetValues(type);
+        }
+        return Array.Empty<object>();
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/PaperTrail.App/Resources/Styles.xaml
+++ b/PaperTrail.App/Resources/Styles.xaml
@@ -4,4 +4,66 @@
         <Setter Property="Margin" Value="2" />
         <Setter Property="Padding" Value="6,2" />
     </Style>
+
+    <!-- Badge style for ContractStatus -->
+    <Style x:Key="StatusBadgeStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="Background" Value="LightGray" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding}" Value="Active">
+                <Setter Property="Background" Value="LightGreen" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding}" Value="ExpiringSoon">
+                <Setter Property="Background" Value="Orange" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding}" Value="Terminated">
+                <Setter Property="Background" Value="LightCoral" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Validation styles -->
+    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Validation.ErrorTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border BorderBrush="Red" BorderThickness="1">
+                        <AdornedElementPlaceholder />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="true">
+                <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+        <Setter Property="Validation.ErrorTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border BorderBrush="Red" BorderThickness="1">
+                        <AdornedElementPlaceholder />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="true">
+                <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Tag chip style -->
+    <Style x:Key="TagChipStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Background" Value="#EEE" />
+        <Setter Property="Margin" Value="2" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="Child" Value="{Binding}" />
+    </Style>
 </ResourceDictionary>

--- a/PaperTrail.App/ViewModels/ContractEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractEditViewModel.cs
@@ -1,10 +1,355 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PaperTrail.App.Services;
 using PaperTrail.Core.Models;
+using PaperTrail.Core.Repositories;
+using PaperTrail.Core.Services;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Windows;
 
 namespace PaperTrail.App.ViewModels;
 
-public partial class ContractEditViewModel : ObservableObject
+public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorInfo
 {
-    [ObservableProperty]
-    private Contract model = new();
+    private readonly IContractRepository _repository;
+    private readonly ImportService _importService;
+    private readonly DialogService _dialogService;
+    private readonly ILicenseService _licenseService;
+
+    private readonly Dictionary<string, List<string>> _errors = new();
+
+    public bool HasErrors => _errors.Any();
+    public IEnumerable<string> ErrorList => _errors.SelectMany(kv => kv.Value);
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+    IEnumerable INotifyDataErrorInfo.GetErrors(string? propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return _errors.SelectMany(kv => kv.Value);
+        return _errors.TryGetValue(propertyName, out var list) ? list : Enumerable.Empty<string>();
+    }
+
+    [ObservableProperty] private Guid id;
+    [ObservableProperty] private string title = string.Empty;
+    [ObservableProperty] private Party? selectedParty;
+    [ObservableProperty] private ObservableCollection<Party> parties = new();
+    [ObservableProperty] private ContractStatus selectedStatus = ContractStatus.Active;
+    [ObservableProperty] private DateOnly? effectiveDate;
+    [ObservableProperty] private DateOnly? renewalDate;
+    [ObservableProperty] private DateOnly? terminationDate;
+    [ObservableProperty] private int? renewalTermMonths;
+    [ObservableProperty] private int? noticePeriodDays;
+    [ObservableProperty] private decimal? valueAmount;
+    [ObservableProperty] private ObservableCollection<string> tags = new();
+    [ObservableProperty] private string newTagText = string.Empty;
+    [ObservableProperty] private ObservableCollection<Attachment> attachments = new();
+    [ObservableProperty] private ObservableCollection<Reminder> reminders = new();
+    [ObservableProperty] private string? notes;
+    [ObservableProperty] private DateOnly? computedNextRenewal;
+    [ObservableProperty] private DateOnly? computedNoticeDate;
+    [ObservableProperty] private bool hasChanges;
+    [ObservableProperty] private bool isPro;
+
+    public IAsyncRelayCommand SaveCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+    public IRelayCommand DeleteCommand { get; }
+    public IRelayCommand AddTagCommand { get; }
+    public IRelayCommand<string> RemoveTagCommand { get; }
+    public IRelayCommand AddPartyCommand { get; }
+    public IAsyncRelayCommand AddAttachmentCommand { get; }
+    public IRelayCommand<Attachment> RemoveAttachmentCommand { get; }
+    public IRelayCommand<Attachment> OpenAttachmentCommand { get; }
+    public IRelayCommand<Attachment> RevealAttachmentCommand { get; }
+    public IAsyncRelayCommand<IDataObject> DragDropAttachmentCommand { get; }
+    public IRelayCommand AddReminderCommand { get; }
+    public IRelayCommand<Reminder> RemoveReminderCommand { get; }
+
+    public ContractEditViewModel(IContractRepository repository, ImportService importService, DialogService dialogService, ILicenseService licenseService)
+    {
+        _repository = repository;
+        _importService = importService;
+        _dialogService = dialogService;
+        _licenseService = licenseService;
+        isPro = _licenseService.IsPro;
+
+        SaveCommand = new AsyncRelayCommand(SaveAsync, CanSave);
+        CancelCommand = new RelayCommand(OnCancel);
+        DeleteCommand = new RelayCommand(OnDelete);
+        AddTagCommand = new RelayCommand(AddTag);
+        RemoveTagCommand = new RelayCommand<string>(RemoveTag);
+        AddPartyCommand = new RelayCommand(AddParty);
+        AddAttachmentCommand = new AsyncRelayCommand(AddAttachmentAsync);
+        RemoveAttachmentCommand = new RelayCommand<Attachment>(RemoveAttachment);
+        OpenAttachmentCommand = new RelayCommand<Attachment>(_ => { });
+        RevealAttachmentCommand = new RelayCommand<Attachment>(_ => { });
+        DragDropAttachmentCommand = new AsyncRelayCommand<IDataObject>(OnDropAsync);
+        AddReminderCommand = new RelayCommand(AddReminder);
+        RemoveReminderCommand = new RelayCommand<Reminder>(r => { if (r != null) Reminders.Remove(r); });
+
+        tags.CollectionChanged += (_, __) => HasChanges = true;
+        attachments.CollectionChanged += (_, __) => HasChanges = true;
+        reminders.CollectionChanged += (_, __) => HasChanges = true;
+    }
+
+    private bool CanSave() => !HasErrors;
+
+    private void OnPropertyChangedAndValidate(string propertyName)
+    {
+        HasChanges = true;
+        ValidateProperty(propertyName);
+        SaveCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnTitleChanged(string value) => OnPropertyChangedAndValidate(nameof(Title));
+    partial void OnSelectedPartyChanged(Party? value) => OnPropertyChangedAndValidate(nameof(SelectedParty));
+    partial void OnEffectiveDateChanged(DateOnly? value) { OnPropertyChangedAndValidate(nameof(EffectiveDate)); RecalculateComputedDates(); }
+    partial void OnRenewalDateChanged(DateOnly? value) { OnPropertyChangedAndValidate(nameof(RenewalDate)); RecalculateComputedDates(); }
+    partial void OnTerminationDateChanged(DateOnly? value) { OnPropertyChangedAndValidate(nameof(TerminationDate)); }
+    partial void OnRenewalTermMonthsChanged(int? value) { OnPropertyChangedAndValidate(nameof(RenewalTermMonths)); RecalculateComputedDates(); }
+    partial void OnNoticePeriodDaysChanged(int? value) { OnPropertyChangedAndValidate(nameof(NoticePeriodDays)); RecalculateComputedDates(); }
+    partial void OnValueAmountChanged(decimal? value) => OnPropertyChangedAndValidate(nameof(ValueAmount));
+    partial void OnNotesChanged(string? value) => OnPropertyChangedAndValidate(nameof(Notes));
+
+    public void RecalculateComputedDates()
+    {
+        DateOnly? next = null;
+        if (renewalDate.HasValue)
+        {
+            next = renewalDate;
+        }
+        else if (effectiveDate.HasValue && renewalTermMonths.HasValue)
+        {
+            try
+            {
+                next = effectiveDate.Value.AddMonths(renewalTermMonths.Value);
+            }
+            catch { }
+        }
+        ComputedNextRenewal = next;
+        if (next.HasValue && noticePeriodDays.HasValue)
+        {
+            try
+            {
+                ComputedNoticeDate = next.Value.AddDays(-noticePeriodDays.Value);
+            }
+            catch { ComputedNoticeDate = null; }
+        }
+        else
+        {
+            ComputedNoticeDate = null;
+        }
+    }
+
+    private void ValidateProperty(string propertyName)
+    {
+        switch (propertyName)
+        {
+            case nameof(Title):
+                ClearErrors(nameof(Title));
+                if (string.IsNullOrWhiteSpace(Title))
+                    AddError(nameof(Title), "Title is required");
+                else if (Title.Length < 3)
+                    AddError(nameof(Title), "Title must be at least 3 characters");
+                break;
+            case nameof(SelectedParty):
+                ClearErrors(nameof(SelectedParty));
+                if (SelectedParty == null)
+                    AddError(nameof(SelectedParty), "Party required");
+                break;
+            case nameof(RenewalTermMonths):
+                ClearErrors(nameof(RenewalTermMonths));
+                if (RenewalTermMonths.HasValue && RenewalTermMonths.Value <= 0)
+                    AddError(nameof(RenewalTermMonths), "Renewal term must be > 0");
+                break;
+            case nameof(ValueAmount):
+                ClearErrors(nameof(ValueAmount));
+                if (ValueAmount.HasValue && ValueAmount.Value < 0)
+                    AddError(nameof(ValueAmount), "Value must be >= 0");
+                break;
+            case nameof(EffectiveDate):
+            case nameof(RenewalDate):
+            case nameof(TerminationDate):
+                ValidateDates();
+                break;
+            case nameof(NoticePeriodDays):
+                ClearErrors(nameof(NoticePeriodDays));
+                if (NoticePeriodDays.HasValue && NoticePeriodDays.Value < 0)
+                    AddError(nameof(NoticePeriodDays), "Notice must be >= 0");
+                break;
+        }
+    }
+
+    private void ValidateDates()
+    {
+        ClearErrors(nameof(EffectiveDate));
+        ClearErrors(nameof(RenewalDate));
+        ClearErrors(nameof(TerminationDate));
+        if (EffectiveDate.HasValue && RenewalDate.HasValue && EffectiveDate > RenewalDate)
+            AddError(nameof(RenewalDate), "Renewal must be after effective date");
+        if (RenewalDate.HasValue && TerminationDate.HasValue && RenewalDate > TerminationDate)
+            AddError(nameof(TerminationDate), "Termination must be after renewal");
+    }
+
+    private void AddError(string prop, string error)
+    {
+        if (!_errors.TryGetValue(prop, out var list))
+        {
+            list = new List<string>();
+            _errors[prop] = list;
+        }
+        if (!list.Contains(error))
+        {
+            list.Add(error);
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(prop));
+            OnPropertyChanged(nameof(ErrorList));
+        }
+    }
+
+    private void ClearErrors(string prop)
+    {
+        if (_errors.Remove(prop))
+        {
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(prop));
+            OnPropertyChanged(nameof(ErrorList));
+        }
+    }
+
+    public List<string> Validate()
+    {
+        var props = new[] { nameof(Title), nameof(SelectedParty), nameof(RenewalTermMonths), nameof(ValueAmount), nameof(EffectiveDate), nameof(RenewalDate), nameof(TerminationDate), nameof(NoticePeriodDays) };
+        foreach (var p in props)
+            ValidateProperty(p);
+        return _errors.SelectMany(e => e.Value).ToList();
+    }
+
+    private async Task SaveAsync()
+    {
+        Validate();
+        if (HasErrors)
+            return;
+        var model = ToModel();
+        if (model.Id == Guid.Empty)
+        {
+            model.Id = Guid.NewGuid();
+            await _repository.AddAsync(model);
+        }
+        else
+        {
+            await _repository.UpdateAsync(model);
+        }
+        var reminderList = ReminderFactory.Create(model).ToList();
+        await _repository.AddRemindersAsync(model.Id, reminderList);
+        Reminders.Clear();
+        foreach (var r in reminderList)
+            Reminders.Add(r);
+        HasChanges = false;
+    }
+
+    private Contract ToModel()
+    {
+        return new Contract
+        {
+            Id = Id,
+            Title = Title,
+            Counterparty = SelectedParty,
+            CounterpartyId = SelectedParty?.Id,
+            Status = SelectedStatus,
+            EffectiveDate = EffectiveDate,
+            RenewalDate = RenewalDate,
+            TerminationDate = TerminationDate,
+            RenewalTermMonths = RenewalTermMonths,
+            NoticePeriodDays = NoticePeriodDays,
+            ValueAmount = ValueAmount,
+            Tags = string.Join(',', Tags),
+            Notes = Notes,
+            Attachments = Attachments.ToList(),
+            Reminders = Reminders.ToList()
+        };
+    }
+
+    private void OnCancel()
+    {
+        if (!HasChanges || MessageBox.Show("Discard changes?", "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+        {
+            Application.Current.Windows.OfType<Window>().SingleOrDefault(w => w.DataContext == this)?.Close();
+        }
+    }
+
+    private void OnDelete()
+    {
+        if (Id != Guid.Empty)
+        {
+            // simple delete
+            _ = _repository.DeleteAsync(Id);
+        }
+        Application.Current.Windows.OfType<Window>().SingleOrDefault(w => w.DataContext == this)?.Close();
+    }
+
+    private void AddTag()
+    {
+        if (!string.IsNullOrWhiteSpace(NewTagText))
+        {
+            Tags.Add(NewTagText.Trim());
+            NewTagText = string.Empty;
+        }
+    }
+
+    private void RemoveTag(string? tag)
+    {
+        if (tag != null)
+            Tags.Remove(tag);
+    }
+
+    private void AddParty()
+    {
+        var p = new Party { Id = Guid.NewGuid(), Name = "New Party" };
+        Parties.Add(p);
+        SelectedParty = p;
+    }
+
+    private async Task AddAttachmentAsync()
+    {
+        var file = _dialogService.OpenFile("All Files|*.*");
+        if (file == null)
+            return;
+        await ImportFileAsync(file);
+    }
+
+    private void RemoveAttachment(Attachment? att)
+    {
+        if (att != null)
+            Attachments.Remove(att);
+    }
+
+    private async Task OnDropAsync(IDataObject? data)
+    {
+        if (data == null || !data.GetDataPresent(DataFormats.FileDrop))
+            return;
+        var files = (string[])data.GetData(DataFormats.FileDrop);
+        foreach (var f in files)
+            await ImportFileAsync(f);
+    }
+
+    private async Task ImportFileAsync(string path)
+    {
+        var attachment = await _importService.ImportAsync(path);
+        if (Attachments.Any(a => a.Hash == attachment.Hash))
+        {
+            MessageBox.Show("Duplicate attachment", "Info");
+            return;
+        }
+        Attachments.Add(attachment);
+    }
+
+    private void AddReminder()
+    {
+        Reminders.Add(new Reminder { Id = Guid.NewGuid(), Type = ReminderType.Custom, DueUtc = DateTime.UtcNow });
+    }
+
+    public bool ConfirmClose()
+    {
+        if (!HasChanges)
+            return true;
+        return MessageBox.Show("Discard changes?", "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+    }
 }

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -1,10 +1,112 @@
 <UserControl x:Class="PaperTrail.App.Views.ContractEditView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="10">
-        <TextBlock Text="Title" />
-        <TextBox Text="{Binding Model.Title}" />
-        <TextBlock Text="Renewal Date" />
-        <DatePicker SelectedDate="{Binding Model.RenewalDate}" />
-    </StackPanel>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:PaperTrail.App.Converters"
+             xmlns:models="clr-namespace:PaperTrail.Core.Models;assembly=PaperTrail.Core"
+             AllowDrop="True">
+    <UserControl.Resources>
+        <conv:EnumToItemsSourceConverter x:Key="EnumConv" />
+    </UserControl.Resources>
+    <Grid RowDefinitions="Auto,*,Auto">
+        <!-- Command Bar -->
+        <DockPanel Margin="4" LastChildFill="False">
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                <Button Content="Save" Command="{Binding SaveCommand}"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}"/>
+                <Button Content="Delete" Command="{Binding DeleteCommand}"/>
+            </StackPanel>
+            <ComboBox Width="120" DockPanel.Dock="Right"
+                      ItemsSource="{Binding Source={x:Type models:ContractStatus}, Converter={StaticResource EnumConv}}"
+                      SelectedItem="{Binding SelectedStatus}"/>
+        </DockPanel>
+
+        <!-- Main Tabs -->
+        <TabControl Grid.Row="1">
+            <!-- Details Tab -->
+            <TabItem Header="Details">
+                <StackPanel Margin="10" >
+                    <TextBlock Text="Party" />
+                    <ComboBox ItemsSource="{Binding Parties}" SelectedItem="{Binding SelectedParty}" IsEditable="True" />
+                    <Button Content="Add Party" Command="{Binding AddPartyCommand}" Width="80" />
+                    <TextBlock Text="Title" Margin="0,8,0,0" />
+                    <TextBox Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock Text="Value" Margin="0,8,0,0" />
+                    <TextBox Text="{Binding ValueAmount, StringFormat=C}" />
+                    <TextBlock Text="Tags" Margin="0,8,0,0" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox Width="120" Text="{Binding NewTagText}" />
+                        <Button Content="Add" Command="{Binding AddTagCommand}"/>
+                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding Tags}" Margin="0,4,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource TagChipStyle}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding}"/>
+                                        <Button Content="✕" Command="{Binding DataContext.RemoveTagCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Dates Tab -->
+            <TabItem Header="Dates">
+                <Grid Margin="10" ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                    <TextBlock Text="Effective" Grid.Row="0"/>
+                    <DatePicker SelectedDate="{Binding EffectiveDate}" Grid.Column="1"/>
+                    <TextBlock Text="Renewal" Grid.Row="1"/>
+                    <DatePicker SelectedDate="{Binding RenewalDate}" Grid.Row="1" Grid.Column="1"/>
+                    <TextBlock Text="Renewal Term (months)" Grid.Row="2"/>
+                    <TextBox Text="{Binding RenewalTermMonths}" Grid.Row="2" Grid.Column="1"/>
+                    <TextBlock Text="Notice Period (days)" Grid.Row="3"/>
+                    <TextBox Text="{Binding NoticePeriodDays}" Grid.Row="3" Grid.Column="1"/>
+                    <TextBlock Text="Termination" Grid.Row="4"/>
+                    <DatePicker SelectedDate="{Binding TerminationDate}" Grid.Row="4" Grid.Column="1"/>
+                    <TextBlock Text="Next Renewal" Grid.Row="5"/>
+                    <TextBox Text="{Binding ComputedNextRenewal}" Grid.Row="5" Grid.Column="1" IsReadOnly="True"/>
+                    <TextBlock Text="Notice Date" Grid.Row="6"/>
+                    <TextBox Text="{Binding ComputedNoticeDate}" Grid.Row="6" Grid.Column="1" IsReadOnly="True"/>
+                </Grid>
+            </TabItem>
+
+            <!-- Attachments Tab -->
+            <TabItem Header="Attachments">
+                <StackPanel Margin="10">
+                    <TextBlock Text="Drag files here to attach" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+                    <ListView ItemsSource="{Binding Attachments}">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="File" DisplayMemberBinding="{Binding FileName}"/>
+                                <GridViewColumn Header="Hash" DisplayMemberBinding="{Binding Hash}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Reminders Tab -->
+            <TabItem Header="Reminders">
+                <StackPanel Margin="10">
+                    <DataGrid ItemsSource="{Binding Reminders}" AutoGenerateColumns="False">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Type" Binding="{Binding Type}" />
+                            <DataGridTextColumn Header="Due" Binding="{Binding DueUtc}" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <Button Content="Add Reminder" Command="{Binding AddReminderCommand}" Width="120" Margin="0,8,0,0"/>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Notes Tab -->
+            <TabItem Header="Notes">
+                <TextBox Text="{Binding Notes}" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            </TabItem>
+        </TabControl>
+
+        <!-- Error summary -->
+        <ItemsControl Grid.Row="2" ItemsSource="{Binding ErrorList}" Margin="4"/>
+    </Grid>
 </UserControl>

--- a/PaperTrail.Core/Models/Contract.cs
+++ b/PaperTrail.Core/Models/Contract.cs
@@ -13,10 +13,13 @@ public class Contract
     public ContractStatus Status { get; set; } = ContractStatus.Active;
     public DateOnly? EffectiveDate { get; set; }
     public DateOnly? RenewalDate { get; set; }
+    [Range(1, 600)]
     public int? RenewalTermMonths { get; set; }
     public DateOnly? TerminationDate { get; set; }
+    [Range(0, 3650)]
     public int? NoticePeriodDays { get; set; }
     public string? Tags { get; set; }
+    [Range(0, 999999999)]
     public decimal? ValueAmount { get; set; }
     public string? Notes { get; set; }
     public bool SensitiveFieldsEncrypted { get; set; }


### PR DESCRIPTION
## Summary
- expand ContractEditViewModel with fields, commands, validation, and computed dates
- introduce tabbed ContractEditView with tag management, dates, attachments, reminders, and error list
- add data annotations and styles plus enum converter and window shortcuts

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c54194701c8329b69d9aceb1bacfe8