### PR TITLE
Fix grid definitions and add DateOnly converter

### DIFF
--- a/PaperTrail.App/Converters/DateOnlyToDateTimeConverter.cs
+++ b/PaperTrail.App/Converters/DateOnlyToDateTimeConverter.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PaperTrail.App.Converters;
+
+public class DateOnlyToDateTimeConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is DateOnly d ? d.ToDateTime(TimeOnly.MinValue) : null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is DateTime dt ? DateOnly.FromDateTime(dt) : null;
+    }
+}

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -6,8 +6,14 @@
              AllowDrop="True">
     <UserControl.Resources>
         <conv:EnumToItemsSourceConverter x:Key="EnumConv" />
+        <conv:DateOnlyToDateTimeConverter x:Key="DateOnlyConv" />
     </UserControl.Resources>
-    <Grid RowDefinitions="Auto,*,Auto">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
         <!-- Command Bar -->
         <DockPanel Margin="4" LastChildFill="False">
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
@@ -43,7 +49,9 @@
                                 <Border Style="{StaticResource TagChipStyle}">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding}"/>
-                                        <Button Content="✕" Command="{Binding DataContext.RemoveTagCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                        <Button Content="✕"
+                                                Command="{Binding DataContext.RemoveTagCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -54,17 +62,30 @@
 
             <!-- Dates Tab -->
             <TabItem Header="Dates">
-                <Grid Margin="10" ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                <Grid Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
                     <TextBlock Text="Effective" Grid.Row="0"/>
-                    <DatePicker SelectedDate="{Binding EffectiveDate}" Grid.Column="1"/>
+                    <DatePicker SelectedDate="{Binding EffectiveDate, Converter={StaticResource DateOnlyConv}}" Grid.Column="1"/>
                     <TextBlock Text="Renewal" Grid.Row="1"/>
-                    <DatePicker SelectedDate="{Binding RenewalDate}" Grid.Row="1" Grid.Column="1"/>
+                    <DatePicker SelectedDate="{Binding RenewalDate, Converter={StaticResource DateOnlyConv}}" Grid.Row="1" Grid.Column="1"/>
                     <TextBlock Text="Renewal Term (months)" Grid.Row="2"/>
                     <TextBox Text="{Binding RenewalTermMonths}" Grid.Row="2" Grid.Column="1"/>
                     <TextBlock Text="Notice Period (days)" Grid.Row="3"/>
                     <TextBox Text="{Binding NoticePeriodDays}" Grid.Row="3" Grid.Column="1"/>
                     <TextBlock Text="Termination" Grid.Row="4"/>
-                    <DatePicker SelectedDate="{Binding TerminationDate}" Grid.Row="4" Grid.Column="1"/>
+                    <DatePicker SelectedDate="{Binding TerminationDate, Converter={StaticResource DateOnlyConv}}" Grid.Row="4" Grid.Column="1"/>
                     <TextBlock Text="Next Renewal" Grid.Row="5"/>
                     <TextBox Text="{Binding ComputedNextRenewal}" Grid.Row="5" Grid.Column="1" IsReadOnly="True"/>
                     <TextBlock Text="Notice Date" Grid.Row="6"/>


### PR DESCRIPTION
## Summary
- Replace string-based Grid definitions with explicit RowDefinitions/ColumnDefinitions in ContractEditView
- Add DateOnlyToDateTimeConverter and apply to DatePicker bindings
- Clean up tag chip removal button markup

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a69896c88329915f25d50453d33c