### PR TITLE
Fix KeyBinding command bindings to use window DataContext

### DIFF
--- a/PaperTrail.App/ContractWindow.xaml
+++ b/PaperTrail.App/ContractWindow.xaml
@@ -5,9 +5,16 @@
         Title="{Binding Title, StringFormat=Edit Contract -- {0}}" Height="600" Width="800"
         Closing="Window_Closing">
     <Window.InputBindings>
-        <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
-        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}" />
+        <KeyBinding Key="S"
+                    Modifiers="Control"
+                    Command="{Binding DataContext.SaveCommand,
+                                      RelativeSource={RelativeSource AncestorType=Window}}" />
+        <KeyBinding Key="Escape"
+                    Command="{Binding DataContext.CancelCommand,
+                                      RelativeSource={RelativeSource AncestorType=Window}}" />
+        <KeyBinding Key="Delete"
+                    Command="{Binding DataContext.DeleteCommand,
+                                      RelativeSource={RelativeSource AncestorType=Window}}" />
     </Window.InputBindings>
     <views:ContractEditView />
 </Window>


### PR DESCRIPTION
## Summary
- Ensure key bindings reference the window's DataContext so commands resolve.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4084f9c83299b391697890d109a