### PR TITLE
Add contract template selection and landing page lists

### DIFF
--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -32,6 +32,7 @@ public partial class App : Application
                     new MongoClient(Environment.GetEnvironmentVariable("MONGODB_URI") ?? "mongodb://localhost:27017"));
                 services.AddSingleton<MongoContext>();
                 services.AddScoped<IContractRepository, ContractRepository>();
+                services.AddScoped<PreviousContractRepository>();
                 services.AddScoped<IPartyRepository, PartyRepository>();
                 services.AddSingleton<INotificationService, NotificationService>();
                 services.AddSingleton<ImportService>();
@@ -42,6 +43,7 @@ public partial class App : Application
                 services.AddSingleton<HashService>();
                 services.AddTransient<ReminderEngine>();
                 services.AddSingleton<MainViewModel>();
+                services.AddSingleton<LandingViewModel>();
                 services.AddSingleton<ContractListViewModel>();
                 services.AddSingleton<ContractEditViewModel>();
                 services.AddSingleton<PartyEditViewModel>();
@@ -64,15 +66,14 @@ public partial class App : Application
         await scheduler.Start();
 
         var settings = scope.ServiceProvider.GetRequiredService<SettingsService>();
-        var mainVm = scope.ServiceProvider.GetRequiredService<MainViewModel>();
-        await mainVm.Contracts.LoadAsync();
-        var mainWindow = new MainWindow { DataContext = mainVm };
-        mainWindow.Show();
+        var landingVm = scope.ServiceProvider.GetRequiredService<LandingViewModel>();
+        var landingWindow = new LandingWindow { DataContext = landingVm };
+        landingWindow.Show();
 
         if (string.IsNullOrWhiteSpace(settings.CompanyName))
         {
             var settingsVm = new SettingsViewModel(settings);
-            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = mainWindow };
+            var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = landingWindow };
             settingsWindow.ShowDialog();
         }
     }

--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -1,12 +1,44 @@
 <Window x:Class="PaperTrail.App.LandingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="PaperTrail Contract Tracker" Height="200" Width="300">
-    <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button Content="Manage Contracts"
-                Command="{Binding OpenMainCommand}"
-                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
-                Margin="0,0,0,10" Width="200" />
-        <Button Content="Settings" Command="{Binding OpenSettingsCommand}" Width="200" />
-    </StackPanel>
+        Title="PaperTrail Contract Tracker" Height="500" Width="700">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="Previous Contracts" Grid.Row="0" Margin="0,0,0,10">
+            <DataGrid ItemsSource="{Binding PreviousContracts}"
+                      SelectedItem="{Binding SelectedPreviousContract}"
+                      AutoGenerateColumns="False"
+                      MouseDoubleClick="PreviousContracts_DoubleClick">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" />
+                    <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" Width="*" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </GroupBox>
+
+        <GroupBox Header="Imported Contracts" Grid.Row="1">
+            <DataGrid ItemsSource="{Binding ImportedContracts}"
+                      SelectedItem="{Binding SelectedImportedContract}"
+                      AutoGenerateColumns="False"
+                      MouseDoubleClick="ImportedContracts_DoubleClick">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" />
+                    <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" Width="*" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </GroupBox>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Manage Contracts"
+                    Command="{Binding OpenMainCommand}"
+                    CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                    Width="150" Margin="0,0,10,0" />
+            <Button Content="Settings" Command="{Binding OpenSettingsCommand}" Width="150" />
+        </StackPanel>
+    </Grid>
 </Window>

--- a/PaperTrail.App/LandingWindow.xaml.cs
+++ b/PaperTrail.App/LandingWindow.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Input;
+using PaperTrail.App.ViewModels;
 
 namespace PaperTrail.App;
 
@@ -7,5 +9,23 @@ public partial class LandingWindow : Window
     public LandingWindow()
     {
         InitializeComponent();
+        Loaded += LandingWindow_Loaded;
+    }
+    private async void LandingWindow_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is LandingViewModel vm)
+            await vm.LoadAsync();
+    }
+
+    private async void PreviousContracts_DoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is LandingViewModel vm)
+            await vm.OpenContractAsync(vm.SelectedPreviousContract, true);
+    }
+
+    private async void ImportedContracts_DoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is LandingViewModel vm)
+            await vm.OpenContractAsync(vm.SelectedImportedContract, false);
     }
 }

--- a/PaperTrail.App/NewContractWindow.xaml
+++ b/PaperTrail.App/NewContractWindow.xaml
@@ -1,0 +1,37 @@
+<Window x:Class="PaperTrail.App.NewContractWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Select Contract Type" Height="450" Width="400">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBox x:Name="SearchBox" Grid.Row="0" Margin="0,0,0,5" TextChanged="SearchBox_TextChanged" />
+
+        <ListBox x:Name="TemplateList" Grid.Row="1">
+            <ListBox.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,5,0,0" />
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListBox.GroupStyle>
+        </ListBox>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Create Selected" Click="CreateSelected_Click" Margin="0,0,10,0" />
+            <Button Content="Cancel" Click="Cancel_Click" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <TextBox x:Name="CustomTitleBox" Width="200" Margin="0,0,10,0" />
+            <Button Content="Create Custom" Click="CreateCustom_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/PaperTrail.App/NewContractWindow.xaml.cs
+++ b/PaperTrail.App/NewContractWindow.xaml.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Data;
+
+namespace PaperTrail.App;
+
+public partial class NewContractWindow : Window
+{
+    private class TemplateInfo
+    {
+        public string Category { get; }
+        public string Title { get; }
+        public TemplateInfo(string category, string title)
+        {
+            Category = category;
+            Title = title;
+        }
+    }
+
+    private readonly ICollectionView _view;
+
+    public string? SelectedTitle { get; private set; }
+
+    public NewContractWindow()
+    {
+        InitializeComponent();
+        var templates = new List<TemplateInfo>
+        {
+            new("📑 Business & Commercial Contracts", "Partnership Agreement"),
+            new("📑 Business & Commercial Contracts", "Shareholders Agreement"),
+            new("📑 Business & Commercial Contracts", "Operating Agreement (LLC Agreement)"),
+            new("📑 Business & Commercial Contracts", "Business Purchase Agreement (M&A)"),
+            new("📑 Business & Commercial Contracts", "Non-Disclosure Agreement (NDA)"),
+            new("📑 Business & Commercial Contracts", "Non-Compete Agreement"),
+            new("📑 Business & Commercial Contracts", "Service Agreement / Consulting Agreement"),
+            new("📑 Business & Commercial Contracts", "Supply Agreement"),
+            new("📑 Business & Commercial Contracts", "Joint Venture Agreement"),
+            new("📑 Business & Commercial Contracts", "Franchise Agreement"),
+            new("⚖️ Employment & HR Contracts", "Employment Agreement"),
+            new("⚖️ Employment & HR Contracts", "Independent Contractor Agreement"),
+            new("⚖️ Employment & HR Contracts", "Severance Agreement"),
+            new("⚖️ Employment & HR Contracts", "Employee Handbook Acknowledgement"),
+            new("⚖️ Employment & HR Contracts", "Equity/Stock Option Agreement"),
+            new("🏠 Real Estate & Property", "Lease Agreement (Residential or Commercial)"),
+            new("🏠 Real Estate & Property", "Purchase & Sale Agreement (Real Estate)"),
+            new("🏠 Real Estate & Property", "Easement Agreement"),
+            new("🏠 Real Estate & Property", "Construction Contract"),
+            new("🏠 Real Estate & Property", "Property Management Agreement"),
+            new("💍 Family & Personal Contracts", "Prenuptial Agreement"),
+            new("💍 Family & Personal Contracts", "Postnuptial Agreement"),
+            new("💍 Family & Personal Contracts", "Separation/Divorce Settlement Agreement"),
+            new("💍 Family & Personal Contracts", "Child Custody Agreement"),
+            new("💍 Family & Personal Contracts", "Power of Attorney"),
+            new("💍 Family & Personal Contracts", "Living Will / Advance Healthcare Directive"),
+            new("📚 Intellectual Property & Creative", "Licensing Agreement"),
+            new("📚 Intellectual Property & Creative", "Publishing Agreement"),
+            new("📚 Intellectual Property & Creative", "Artist/Recording Contract"),
+            new("📚 Intellectual Property & Creative", "Software Development Agreement"),
+            new("📚 Intellectual Property & Creative", "SaaS Agreement"),
+            new("💰 Finance & Lending", "Loan Agreement / Promissory Note"),
+            new("💰 Finance & Lending", "Guaranty Agreement"),
+            new("💰 Finance & Lending", "Security Agreement"),
+            new("💰 Finance & Lending", "Investment Agreement"),
+            new("🏛️ Government & Compliance", "Government Contract (Procurement)"),
+            new("🏛️ Government & Compliance", "Compliance Agreement / Consent Decree"),
+            new("🏛️ Government & Compliance", "Data Processing Agreement (DPA)"),
+            new("📦 Miscellaneous / General Use", "Settlement Agreement"),
+            new("📦 Miscellaneous / General Use", "Mediation/Arbitration Agreement"),
+            new("📦 Miscellaneous / General Use", "General Release of Claims"),
+            new("📦 Miscellaneous / General Use", "Waiver & Indemnity Agreement")
+        };
+
+        _view = CollectionViewSource.GetDefaultView(templates);
+        _view.GroupDescriptions.Add(new PropertyGroupDescription(nameof(TemplateInfo.Category)));
+        TemplateList.ItemsSource = _view;
+    }
+
+    private void SearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+    {
+        var text = SearchBox.Text;
+        _view.Filter = item => string.IsNullOrWhiteSpace(text) ||
+            ((TemplateInfo)item).Title.Contains(text, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void CreateSelected_Click(object sender, RoutedEventArgs e)
+    {
+        if (TemplateList.SelectedItem is TemplateInfo info)
+        {
+            SelectedTitle = info.Title;
+            DialogResult = true;
+        }
+    }
+
+    private void CreateCustom_Click(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(CustomTitleBox.Text))
+        {
+            SelectedTitle = CustomTitleBox.Text;
+            DialogResult = true;
+        }
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -58,7 +58,12 @@ public partial class ContractListViewModel : ObservableObject
 
     private async Task NewAsync()
     {
-        var contract = new Contract { Id = Guid.NewGuid(), Title = "New Contract" };
+        var selector = new NewContractWindow();
+        if (selector.ShowDialog() != true)
+            return;
+
+        var title = string.IsNullOrWhiteSpace(selector.SelectedTitle) ? "New Contract" : selector.SelectedTitle;
+        var contract = new Contract { Id = Guid.NewGuid(), Title = title };
         await _contracts.AddAsync(contract);
         var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license);
         vm.LoadFromModel(contract);
@@ -80,6 +85,15 @@ public partial class ContractListViewModel : ObservableObject
         if (file == null) return;
         await _import.ImportAsync(SelectedContract.Id, file);
         MessageBox.Show("Import completed.", "Import", MessageBoxButton.OK, MessageBoxImage.Information);
+
+        var model = await _contracts.GetByIdAsync(SelectedContract.Id);
+        if (model != null)
+        {
+            var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license);
+            vm.LoadFromModel(model);
+            var win = new ContractWindow { DataContext = vm };
+            win.ShowDialog();
+        }
     }
 
     private async Task ExportAsync()

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -1,9 +1,14 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using System.Windows;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using System.Windows;
 using PaperTrail.App.Services;
+using PaperTrail.Core.DTO;
+using PaperTrail.Core.Models;
+using PaperTrail.Core.Repositories;
 using PaperTrail.App;
+using PaperTrail.Core.Services;
 
 namespace PaperTrail.App.ViewModels;
 
@@ -11,14 +16,39 @@ public class LandingViewModel : ObservableObject
 {
     private readonly MainViewModel _mainViewModel;
     private readonly SettingsService _settings;
+    private readonly IContractRepository _importedRepo;
+    private readonly PreviousContractRepository _previousRepo;
+    private readonly ImportService _importService;
+    private readonly DialogService _dialogService;
+    private readonly ILicenseService _licenseService;
+
+    public ObservableCollection<Contract> PreviousContracts { get; } = new();
+    public ObservableCollection<Contract> ImportedContracts { get; } = new();
+
+    [ObservableProperty]
+    private Contract? selectedPreviousContract;
+
+    [ObservableProperty]
+    private Contract? selectedImportedContract;
 
     public IAsyncRelayCommand<Window> OpenMainCommand { get; }
     public IRelayCommand OpenSettingsCommand { get; }
 
-    public LandingViewModel(MainViewModel mainViewModel, SettingsService settings)
+    public LandingViewModel(MainViewModel mainViewModel,
+                            SettingsService settings,
+                            IContractRepository importedRepo,
+                            PreviousContractRepository previousRepo,
+                            ImportService importService,
+                            DialogService dialogService,
+                            ILicenseService licenseService)
     {
         _mainViewModel = mainViewModel;
         _settings = settings;
+        _importedRepo = importedRepo;
+        _previousRepo = previousRepo;
+        _importService = importService;
+        _dialogService = dialogService;
+        _licenseService = licenseService;
         OpenMainCommand = new AsyncRelayCommand<Window>(OpenMainAsync);
         OpenSettingsCommand = new RelayCommand(OpenSettings);
     }
@@ -36,5 +66,34 @@ public class LandingViewModel : ObservableObject
         var vm = new SettingsViewModel(_settings);
         var win = new SettingsWindow { DataContext = vm };
         win.ShowDialog();
+    }
+
+    public async Task LoadAsync()
+    {
+        PreviousContracts.Clear();
+        var prev = await _previousRepo.GetAllAsync(new FilterOptions());
+        foreach (var c in prev)
+            PreviousContracts.Add(c);
+
+        ImportedContracts.Clear();
+        var imp = await _importedRepo.GetAllAsync(new FilterOptions());
+        foreach (var c in imp)
+            ImportedContracts.Add(c);
+    }
+
+    public async Task OpenContractAsync(Contract? contract, bool isPrevious)
+    {
+        if (contract == null)
+            return;
+
+        var repo = isPrevious ? (IContractRepository)_previousRepo : _importedRepo;
+        var model = await repo.GetByIdAsync(contract.Id);
+        if (model == null) return;
+
+        var vm = new ContractEditViewModel(repo, _importService, _dialogService, _licenseService);
+        vm.LoadFromModel(model);
+        var win = new ContractWindow { DataContext = vm };
+        win.ShowDialog();
+        await LoadAsync();
     }
 }


### PR DESCRIPTION
## Summary
- show previous and imported contracts on the landing screen and open them with a double-click
- allow choosing from categorized contract templates with search support or a custom title when creating a new contract
- open imported contracts for review and editing immediately after import

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7eb8e1c8329a950c5747e3ccd92