### PR TITLE
Add menu navigation for settings and contracts

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -4,7 +4,22 @@
         xmlns:views="clr-namespace:PaperTrail.App.Views"
         Title="PaperTrail Contract Tracker" Height="500" Width="800">
     <Grid>
-        <Grid x:Name="LandingGrid" Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Menu Grid.Row="0">
+            <MenuItem Header="_Home">
+                <MenuItem Header="_Home" Command="{Binding ShowHomeCommand}" />
+                <MenuItem Header="_Manage Contracts" Command="{Binding OpenMainCommand}" />
+            </MenuItem>
+            <MenuItem Header="_File">
+                <MenuItem Header="_Settings" Command="{Binding OpenSettingsCommand}" />
+            </MenuItem>
+        </Menu>
+
+        <Grid x:Name="LandingGrid" Grid.Row="1" Margin="10">
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Setter Property="Visibility" Value="Visible"/>
@@ -16,12 +31,14 @@
                 </Style>
             </Grid.Style>
             <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <GroupBox Header="Previous Contracts" Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="Home" FontSize="16" FontWeight="Bold" Margin="0,0,0,10" />
+
+            <GroupBox Header="Previous Contracts" Grid.Row="1" Margin="0,0,0,10">
                 <DataGrid ItemsSource="{Binding PreviousContracts}"
                           SelectedItem="{Binding SelectedPreviousContract}"
                           AutoGenerateColumns="False"
@@ -33,7 +50,7 @@
                 </DataGrid>
             </GroupBox>
 
-            <GroupBox Header="Imported Contracts" Grid.Row="1">
+            <GroupBox Header="Imported Contracts" Grid.Row="2">
                 <DataGrid ItemsSource="{Binding ImportedContracts}"
                           SelectedItem="{Binding SelectedImportedContract}"
                           AutoGenerateColumns="False"
@@ -44,16 +61,9 @@
                     </DataGrid.Columns>
                 </DataGrid>
             </GroupBox>
-
-            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Manage Contracts"
-                        Command="{Binding OpenMainCommand}"
-                        Width="150" Margin="0,0,10,0"/>
-                <Button Content="Settings" Command="{Binding OpenSettingsCommand}" Width="150"/>
-            </StackPanel>
         </Grid>
 
-        <Grid x:Name="MainGrid" DataContext="{Binding Main}">
+        <Grid x:Name="MainGrid" Grid.Row="1" DataContext="{Binding Main}">
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -66,22 +76,16 @@
             </Grid.Style>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition/>
             </Grid.RowDefinitions>
-            <Menu>
-                <MenuItem Header="_File">
-                    <MenuItem Header="_Settings" Command="{Binding OpenSettingsCommand}" />
-                </MenuItem>
-            </Menu>
-            <ToolBar Grid.Row="1" DataContext="{Binding Contracts}">
+            <ToolBar Grid.Row="0" DataContext="{Binding Contracts}">
                 <Button Content="New Contract" Command="{Binding NewCommand}" />
                 <Button Content="Import PDF" Command="{Binding ImportCommand}" />
                 <Button Content="Export CSV" Command="{Binding ExportCommand}" />
                 <TextBox Width="200" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
                 <Button Content="Search" Command="{Binding RefreshCommand}" />
             </ToolBar>
-            <views:ContractListView Grid.Row="2" DataContext="{Binding Contracts}" />
+            <views:ContractListView Grid.Row="1" DataContext="{Binding Contracts}" />
         </Grid>
     </Grid>
 </Window>

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -59,6 +59,7 @@ public partial class LandingViewModel : ObservableObject
 
     public IAsyncRelayCommand OpenMainCommand { get; }
     public IRelayCommand OpenSettingsCommand { get; }
+    public IRelayCommand ShowHomeCommand { get; }
 
     public LandingViewModel(MainViewModel mainViewModel,
                             SettingsService settings,
@@ -77,6 +78,7 @@ public partial class LandingViewModel : ObservableObject
         _licenseService = licenseService;
         OpenMainCommand = new AsyncRelayCommand(OpenMainAsync);
         OpenSettingsCommand = new RelayCommand(OpenSettings);
+        ShowHomeCommand = new RelayCommand(ShowHome);
     }
 
     private async Task OpenMainAsync()
@@ -90,6 +92,11 @@ public partial class LandingViewModel : ObservableObject
         var vm = new SettingsViewModel(_settings);
         var win = new SettingsWindow { DataContext = vm };
         win.ShowDialog();
+    }
+
+    private void ShowHome()
+    {
+        IsMainViewVisible = false;
     }
 
     public async Task LoadAsync()


### PR DESCRIPTION
## Summary
- Add top-level File and Home menu for navigation
- Allow returning to Home view and managing contracts
- Display previous and imported contracts under a Home heading

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while attempting to install .NET)*

------
https://chatgpt.com/codex/tasks/task_e_68c603473b0c83298095495a668b1712