### PR TITLE
Prevent editing and empty rows in contract lists

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -42,6 +42,8 @@
                 <DataGrid ItemsSource="{Binding PreviousContracts}"
                           SelectedItem="{Binding SelectedPreviousContract}"
                           AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          CanUserAddRows="False"
                           MouseDoubleClick="PreviousContracts_DoubleClick">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>
@@ -54,6 +56,8 @@
                 <DataGrid ItemsSource="{Binding ImportedContracts}"
                           SelectedItem="{Binding SelectedImportedContract}"
                           AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          CanUserAddRows="False"
                           MouseDoubleClick="ImportedContracts_DoubleClick">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>


### PR DESCRIPTION
## Summary
- remove blank new-item row from landing page contract lists
- make previous and imported contract grids read-only

## Testing
- ⚠️ `dotnet build` *(dotnet not installed; `apt-get` update blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c608892e1083298bf404e7b2362678