### PR TITLE
Track recent contracts and add app visuals

### DIFF
--- a/PaperTrail.App/ContractWindow.xaml
+++ b/PaperTrail.App/ContractWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:PaperTrail.App.Views"
         Title="{Binding Title, StringFormat=Edit Contract -- {0}}" Height="600" Width="800"
+        Icon="Resources/IconsAndImages/PaperTrailIcon.ico"
         Closing="Window_Closing">
     <Window.InputBindings>
         <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />

--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:PaperTrail.App.Views"
-        Title="PaperTrail Contract Tracker" Height="500" Width="800">
+        Title="PaperTrail Contract Tracker" Height="500" Width="800"
+        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -69,6 +70,9 @@
         </Grid>
 
         <Grid x:Name="MainGrid" Grid.Row="1" DataContext="{Binding Main}">
+            <Grid.Background>
+                <ImageBrush ImageSource="Resources/IconsAndImages/PaperTrailBackground.png" Stretch="UniformToFill" />
+            </Grid.Background>
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Setter Property="Visibility" Value="Collapsed"/>

--- a/PaperTrail.App/NewContractWindow.xaml
+++ b/PaperTrail.App/NewContractWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="PaperTrail.App.NewContractWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Select Contract Type" Height="450" Width="400">
+        Title="Select Contract Type" Height="450" Width="400"
+        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/PaperTrail.App/PaperTrail.App.csproj
+++ b/PaperTrail.App/PaperTrail.App.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ApplicationIcon>Resources\IconsAndImages\PaperTrailIcon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\IconsAndImages\PaperTrailBackground.png" />

--- a/PaperTrail.App/SettingsWindow.xaml
+++ b/PaperTrail.App/SettingsWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="PaperTrail.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Settings" Height="300" Width="300">
+        Title="Settings" Height="300" Width="300"
+        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
     <StackPanel Margin="10">
         <TextBlock Text="Company Name" />
         <TextBox Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" />

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -121,6 +121,8 @@ public partial class LandingViewModel : ObservableObject
         var model = await repo.GetByIdAsync(contract.Id);
         if (model == null) return;
 
+        await _previousRepo.AddOrUpdateAsync(model);
+
         var vm = new ContractEditViewModel(repo, _importService, _dialogService, _licenseService);
         vm.LoadFromModel(model);
         var win = new ContractWindow { DataContext = vm };


### PR DESCRIPTION
## Summary
- Track and sort previous contracts, keeping only the 30 most recently opened
- Set application icon and add background image for manage contracts view

## Testing
- ⚠️ `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60afb5c148329aea881a7d6160adc