### PR TITLE
Use pack URIs for resource references

### DIFF
--- a/PaperTrail.App/ContractWindow.xaml
+++ b/PaperTrail.App/ContractWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:PaperTrail.App.Views"
         Title="{Binding Title, StringFormat=Edit Contract -- {0}}" Height="600" Width="800"
-        Icon="Resources/IconsAndImages/PaperTrailIcon.ico"
+        Icon="pack://application:,,,/Resources/IconsAndImages/PaperTrailIcon.ico"
         Closing="Window_Closing">
     <Window.InputBindings>
         <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />

--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:PaperTrail.App.Views"
         Title="PaperTrail Contract Tracker" Height="500" Width="800"
-        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
+        Icon="pack://application:,,,/Resources/IconsAndImages/PaperTrailIcon.ico">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -71,7 +71,7 @@
 
         <Grid x:Name="MainGrid" Grid.Row="1" DataContext="{Binding Main}">
             <Grid.Background>
-                <ImageBrush ImageSource="Resources/IconsAndImages/PaperTrailBackground.png" Stretch="UniformToFill" />
+                <ImageBrush ImageSource="pack://application:,,,/Resources/IconsAndImages/PaperTrailBackground.png" Stretch="UniformToFill" />
             </Grid.Background>
             <Grid.Style>
                 <Style TargetType="Grid">

--- a/PaperTrail.App/NewContractWindow.xaml
+++ b/PaperTrail.App/NewContractWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Select Contract Type" Height="450" Width="400"
-        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
+        Icon="pack://application:,,,/Resources/IconsAndImages/PaperTrailIcon.ico">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/PaperTrail.App/SettingsWindow.xaml
+++ b/PaperTrail.App/SettingsWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Settings" Height="300" Width="300"
-        Icon="Resources/IconsAndImages/PaperTrailIcon.ico">
+        Icon="pack://application:,,,/Resources/IconsAndImages/PaperTrailIcon.ico">
     <StackPanel Margin="10">
         <TextBlock Text="Company Name" />
         <TextBox Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" />


### PR DESCRIPTION
## Summary
- Switch window icons to pack://application URIs
- Reference background image via pack URI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6126bb1948329b3a267ba90dcb065