### PR TITLE
Fix DI lifetime for repositories

### DIFF
--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -31,9 +31,11 @@ public partial class App : Application
                 services.AddSingleton<IMongoClient>(_ =>
                     new MongoClient(Environment.GetEnvironmentVariable("MONGODB_URI") ?? "mongodb+srv://fiwbsolutions:lDQlujC1r9yV0uc4@fiwb-cluster.icshfk2.mongodb.net/"));
                 services.AddSingleton<MongoContext>();
-                services.AddScoped<IContractRepository, ContractRepository>();
-                services.AddScoped<PreviousContractRepository>();
-                services.AddScoped<IPartyRepository, PartyRepository>();
+                // Use singleton lifetime for repositories so they can be injected into
+                // singleton view models without lifetime conflicts
+                services.AddSingleton<IContractRepository, ContractRepository>();
+                services.AddSingleton<PreviousContractRepository>();
+                services.AddSingleton<IPartyRepository, PartyRepository>();
                 services.AddSingleton<INotificationService, NotificationService>();
                 services.AddSingleton<ImportService>();
                 services.AddSingleton<ExportService>();


### PR DESCRIPTION
## Summary
- avoid lifetime mismatch by registering repositories as singletons

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c6143eb6a48329802399a1739cee83