### PR TITLE
Add custom contract storage and imported contract deletion

### DIFF
--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -18,6 +18,8 @@ public partial class App : Application
 {
     private IHost? _host;
 
+    public static IServiceProvider Services => ((App)Current)._host!.Services;
+
     protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
@@ -36,6 +38,7 @@ public partial class App : Application
                 services.AddSingleton<IContractRepository, ContractRepository>();
                 services.AddSingleton<PreviousContractRepository>();
                 services.AddSingleton<IPartyRepository, PartyRepository>();
+                services.AddSingleton<ICustomContractRepository, CustomContractRepository>();
                 services.AddSingleton<INotificationService, NotificationService>();
                 services.AddSingleton<ImportService>();
                 services.AddSingleton<ExportService>();

--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -64,6 +64,13 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>
                         <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" Width="*"/>
+                        <DataGridTemplateColumn Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Delete" Command="{Binding DataContext.DeleteImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
             </GroupBox>

--- a/PaperTrail.App/NewContractWindow.xaml
+++ b/PaperTrail.App/NewContractWindow.xaml
@@ -13,7 +13,7 @@
 
         <TextBox x:Name="SearchBox" Grid.Row="0" Margin="0,0,0,5" TextChanged="SearchBox_TextChanged" />
 
-        <ListBox x:Name="TemplateList" Grid.Row="1">
+        <ListBox x:Name="TemplateList" Grid.Row="1" DisplayMemberPath="Title">
             <ListBox.GroupStyle>
                 <GroupStyle>
                     <GroupStyle.HeaderTemplate>

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -85,7 +85,8 @@ public partial class ContractListViewModel : ObservableObject
 
     private async Task NewAsync()
     {
-        var selector = new NewContractWindow();
+        var repo = App.Services.GetRequiredService<ICustomContractRepository>();
+        var selector = new NewContractWindow(repo);
         if (selector.ShowDialog() != true)
             return;
 

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -60,6 +60,7 @@ public partial class LandingViewModel : ObservableObject
     public IAsyncRelayCommand OpenMainCommand { get; }
     public IRelayCommand OpenSettingsCommand { get; }
     public IRelayCommand ShowHomeCommand { get; }
+    public IAsyncRelayCommand<Contract> DeleteImportedContractCommand { get; }
 
     public LandingViewModel(MainViewModel mainViewModel,
                             SettingsService settings,
@@ -79,6 +80,7 @@ public partial class LandingViewModel : ObservableObject
         OpenMainCommand = new AsyncRelayCommand(OpenMainAsync);
         OpenSettingsCommand = new RelayCommand(OpenSettings);
         ShowHomeCommand = new RelayCommand(ShowHome);
+        DeleteImportedContractCommand = new AsyncRelayCommand<Contract>(DeleteImportedContractAsync);
     }
 
     private async Task OpenMainAsync()
@@ -127,6 +129,14 @@ public partial class LandingViewModel : ObservableObject
         vm.LoadFromModel(model);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
+        await LoadAsync();
+    }
+
+    private async Task DeleteImportedContractAsync(Contract? contract)
+    {
+        if (contract == null)
+            return;
+        await _importedRepo.DeleteAsync(contract.Id);
         await LoadAsync();
     }
 }

--- a/PaperTrail.Core/Data/MongoContext.cs
+++ b/PaperTrail.Core/Data/MongoContext.cs
@@ -16,6 +16,7 @@ public class MongoContext
     public IMongoCollection<Models.Party> Parties => Database.GetCollection<Models.Party>("Parties");
     public IMongoCollection<Models.Contract> PreviousContracts => Database.GetCollection<Models.Contract>("PreviousContracts");
     public IMongoCollection<Models.Reminder> Reminders => Database.GetCollection<Models.Reminder>("Reminders");
+    public IMongoCollection<Models.CustomContract> CustomContracts => Database.GetCollection<Models.CustomContract>("CustomContracts");
 
     public MongoContext(IMongoClient client)
     {

--- a/PaperTrail.Core/Models/CustomContract.cs
+++ b/PaperTrail.Core/Models/CustomContract.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PaperTrail.Core.Models;
+
+public class CustomContract
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public string Title { get; set; } = string.Empty;
+}

--- a/PaperTrail.Core/Repositories/CustomContractRepository.cs
+++ b/PaperTrail.Core/Repositories/CustomContractRepository.cs
@@ -1,0 +1,20 @@
+using MongoDB.Driver;
+using PaperTrail.Core.Data;
+using PaperTrail.Core.Models;
+
+namespace PaperTrail.Core.Repositories;
+
+public class CustomContractRepository : ICustomContractRepository
+{
+    private readonly MongoContext _context;
+    public CustomContractRepository(MongoContext context) => _context = context;
+
+    public Task<List<CustomContract>> GetAllAsync(CancellationToken token = default)
+        => _context.CustomContracts.Find(_ => true).SortBy(c => c.Title).ToListAsync(token);
+
+    public Task AddAsync(CustomContract contract, CancellationToken token = default)
+        => _context.CustomContracts.InsertOneAsync(contract, cancellationToken: token);
+
+    public Task DeleteAsync(Guid id, CancellationToken token = default)
+        => _context.CustomContracts.DeleteOneAsync(c => c.Id == id, token);
+}

--- a/PaperTrail.Core/Repositories/ICustomContractRepository.cs
+++ b/PaperTrail.Core/Repositories/ICustomContractRepository.cs
@@ -1,0 +1,10 @@
+using PaperTrail.Core.Models;
+
+namespace PaperTrail.Core.Repositories;
+
+public interface ICustomContractRepository
+{
+    Task<List<CustomContract>> GetAllAsync(CancellationToken token = default);
+    Task AddAsync(CustomContract contract, CancellationToken token = default);
+    Task DeleteAsync(Guid id, CancellationToken token = default);
+}


### PR DESCRIPTION
## Summary
- allow deleting imported contracts directly from home screen
- persist custom contract templates in MongoDB and show under Custom category when creating new contracts
- fix contract template list to display titles instead of type names

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b9095f88329a750dca47d13dbab