### PR TITLE
Confirm imported contract deletion and widen delete column

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -64,10 +64,13 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>
                         <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" Width="*"/>
-                        <DataGridTemplateColumn Width="Auto">
+                        <DataGridTemplateColumn Width="*" MinWidth="75">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <Button Content="Delete" Command="{Binding DataContext.DeleteImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                                    <Button Content="Delete"
+                                            Command="{Binding DataContext.DeleteImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                            CommandParameter="{Binding}"
+                                            HorizontalAlignment="Stretch" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -136,6 +136,10 @@ public partial class LandingViewModel : ObservableObject
     {
         if (contract == null)
             return;
+        var created = contract.CreatedUtc.ToLocalTime();
+        var message = $"Are you sure you want to delete \"{contract.Title}\" created on {created:yyyy-MM-dd}?";
+        if (MessageBox.Show(message, "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
+            return;
         await _importedRepo.DeleteAsync(contract.Id);
         await LoadAsync();
     }


### PR DESCRIPTION
## Summary
- add confirmation dialog when deleting imported contracts including contract title and creation date
- widen imported contracts delete column and stretch button for readability

## Testing
- `dotnet build PaperTrail.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c61da80f1c83299e087f688cb86339