### PR TITLE
Set creation date for new contracts and clean up previous entries on delete

### DIFF
--- a/PaperTrail.App/ViewModels/ContractEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractEditViewModel.cs
@@ -49,6 +49,7 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
     private readonly ILicenseService _licenseService;
 
     private readonly Dictionary<string, List<string>> _errors = new();
+    private DateTime _createdUtc;
 
     public bool HasErrors => _errors.Any();
     public IEnumerable<string> ErrorList => _errors.SelectMany(kv => kv.Value);
@@ -240,6 +241,7 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
                 Reminders.Add(r);
 
         Notes = model.Notes;
+        _createdUtc = model.CreatedUtc;
 
         RecalculateComputedDates();
         HasChanges = false;
@@ -443,10 +445,14 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
         if (model.Id == Guid.Empty)
         {
             model.Id = Guid.NewGuid();
+            model.CreatedUtc = DateTime.UtcNow;
+            model.UpdatedUtc = model.CreatedUtc;
             await _repository.AddAsync(model);
         }
         else
         {
+            model.CreatedUtc = _createdUtc;
+            model.UpdatedUtc = DateTime.UtcNow;
             await _repository.UpdateAsync(model);
         }
 

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -91,7 +91,14 @@ public partial class ContractListViewModel : ObservableObject
             return;
 
         var title = string.IsNullOrWhiteSpace(selector.SelectedTitle) ? "New Contract" : selector.SelectedTitle;
-        var contract = new Contract { Id = Guid.NewGuid(), Title = title };
+        var now = DateTime.UtcNow;
+        var contract = new Contract
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            CreatedUtc = now,
+            UpdatedUtc = now
+        };
         await _contracts.AddAsync(contract);
         var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license);
         vm.LoadFromModel(contract);

--- a/PaperTrail.Core/Repositories/ContractRepository.cs
+++ b/PaperTrail.Core/Repositories/ContractRepository.cs
@@ -53,8 +53,11 @@ public class ContractRepository : IContractRepository
     public Task UpdateAsync(Contract contract, CancellationToken token = default)
         => _context.ImportedContracts.ReplaceOneAsync(c => c.Id == contract.Id, contract, cancellationToken: token);
 
-    public Task DeleteAsync(Guid id, CancellationToken token = default)
-        => _context.ImportedContracts.DeleteOneAsync(c => c.Id == id, token);
+    public async Task DeleteAsync(Guid id, CancellationToken token = default)
+    {
+        await _context.ImportedContracts.DeleteOneAsync(c => c.Id == id, token);
+        await _context.PreviousContracts.DeleteOneAsync(c => c.Id == id, token);
+    }
 
     public async Task AddAttachmentAsync(Guid contractId, Attachment attachment, CancellationToken token = default)
     {


### PR DESCRIPTION
## Summary
- record current UTC time as CreatedUtc/UpdatedUtc when a contract is created
- ensure deleting an imported contract also removes it from previous contracts
- preserve original creation date and update timestamps when saving contracts

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6201132cc832993e0aaf47a77bde5