### PR TITLE
Add client management and contract duplication

### DIFF
--- a/PaperTrail.App/LandingWindow.xaml
+++ b/PaperTrail.App/LandingWindow.xaml
@@ -64,13 +64,17 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>
                         <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" Width="*"/>
-                        <DataGridTemplateColumn Width="100" MinWidth="75">
+                        <DataGridTemplateColumn Width="200" MinWidth="150">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <Button Content="Delete"
-                                            Command="{Binding DataContext.DeleteImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                            CommandParameter="{Binding}"
-                                            HorizontalAlignment="Stretch" />
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <Button Content="Duplicate &amp; Change"
+                                                Command="{Binding DataContext.DuplicateImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                CommandParameter="{Binding}" Margin="0,0,6,0"/>
+                                        <Button Content="Delete"
+                                                Command="{Binding DataContext.DeleteImportedContractCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                CommandParameter="{Binding}"/>
+                                    </StackPanel>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -100,12 +100,15 @@ public partial class ContractListViewModel : ObservableObject
             UpdatedUtc = now
         };
         await _contracts.AddAsync(contract);
-        var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license);
+        var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
+        var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo);
         vm.LoadFromModel(contract);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
         await LoadAsync();
         SelectedContract = Items.FirstOrDefault(c => c.Id == contract.Id);
+        var landing = App.Services.GetRequiredService<LandingViewModel>();
+        await landing.LoadAsync();
     }
 
     private async Task ImportAsync()
@@ -124,7 +127,8 @@ public partial class ContractListViewModel : ObservableObject
         var model = await _contracts.GetByIdAsync(SelectedContract.Id);
         if (model != null)
         {
-            var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license);
+            var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
+            var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo);
             vm.LoadFromModel(model);
             var win = new ContractWindow { DataContext = vm };
             win.ShowDialog();

--- a/PaperTrail.App/ViewModels/PartyEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/PartyEditViewModel.cs
@@ -1,43 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using CsvHelper;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Toolkit.Uwp.Notifications;
-using MongoDB.Bson;
-using MongoDB.Driver;
-using Ookii.Dialogs.Wpf;
-using PaperTrail.App.Services;
-using PaperTrail.App.ViewModels;
-using PaperTrail.App;
-using PaperTrail.Core.DTO;
-using PaperTrail.Core.Data;
 using PaperTrail.Core.Models;
-using PaperTrail.Core.Repositories;
-using PaperTrail.Core.Services;
-using Quartz.Impl;
-using Quartz.Spi;
-using Quartz;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text.Json;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Data;
-using System.Windows.Input;
 using System.Windows;
-using System;
-using Windows.UI.Notifications;
-
 
 namespace PaperTrail.App.ViewModels;
 
@@ -45,4 +10,31 @@ public partial class PartyEditViewModel : ObservableObject
 {
     [ObservableProperty]
     private Party model = new();
+
+    public IRelayCommand SaveCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public PartyEditViewModel()
+    {
+        SaveCommand = new RelayCommand(OnSave);
+        CancelCommand = new RelayCommand(OnCancel);
+    }
+
+    private void OnSave()
+    {
+        CloseWindow(true);
+    }
+
+    private void OnCancel()
+    {
+        CloseWindow(false);
+    }
+
+    private void CloseWindow(bool result)
+    {
+        var win = Application.Current.Windows.OfType<Window>()
+                     .SingleOrDefault(w => ReferenceEquals(w.DataContext, this));
+        if (win != null)
+            win.DialogResult = result;
+    }
 }

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -46,12 +46,13 @@
             <TabItem Header="Details">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="12">
-                        <TextBlock Text="Party"/>
+                        <TextBlock Text="Client"/>
+                        <TextBox Text="{Binding PartySearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,4"/>
                         <ComboBox ItemsSource="{Binding Parties}"
                                   SelectedItem="{Binding SelectedParty}"
-                                  IsEditable="True" />
+                                  DisplayMemberPath="Name" />
 
-                        <Button Content="Add Party"
+                        <Button Content="Add Client"
                                 Command="{Binding AddPartyCommand}"
                                 Width="120"
                                 Margin="0,6,0,0" />

--- a/PaperTrail.App/Views/PartyEditView.xaml
+++ b/PaperTrail.App/Views/PartyEditView.xaml
@@ -1,8 +1,0 @@
-<UserControl x:Class="PaperTrail.App.Views.PartyEditView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="10">
-        <TextBlock Text="Name" />
-        <TextBox Text="{Binding Model.Name}" />
-    </StackPanel>
-</UserControl>

--- a/PaperTrail.App/Views/PartyEditWindow.xaml
+++ b/PaperTrail.App/Views/PartyEditWindow.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="PaperTrail.App.Views.PartyEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Client" Height="320" Width="400">
+    <StackPanel Margin="10">
+        <TextBlock Text="Name" />
+        <TextBox Text="{Binding Model.Name}" />
+        <TextBlock Text="Email" Margin="0,10,0,0" />
+        <TextBox Text="{Binding Model.ContactEmail}" />
+        <TextBlock Text="Phone" Margin="0,10,0,0" />
+        <TextBox Text="{Binding Model.ContactPhone}" />
+        <TextBlock Text="Address" Margin="0,10,0,0" />
+        <TextBox Text="{Binding Model.Address}" Height="60" AcceptsReturn="True" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Save" Width="75" Margin="0,0,6,0" Command="{Binding SaveCommand}" />
+            <Button Content="Cancel" Width="75" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/PaperTrail.App/Views/PartyEditWindow.xaml.cs
+++ b/PaperTrail.App/Views/PartyEditWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace PaperTrail.App.Views;
+
+public partial class PartyEditWindow : Window
+{
+    public PartyEditWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/PaperTrail.Core/Data/MongoContext.cs
+++ b/PaperTrail.Core/Data/MongoContext.cs
@@ -13,6 +13,7 @@ public class MongoContext
 
     public IMongoCollection<Models.Attachment> Attachments => Database.GetCollection<Models.Attachment>("Attachments");
     public IMongoCollection<Models.Contract> ImportedContracts => Database.GetCollection<Models.Contract>("ImportedContracts");
+    public IMongoCollection<Models.Party> Clients => Database.GetCollection<Models.Party>("Clients");
     public IMongoCollection<Models.Party> Parties => Database.GetCollection<Models.Party>("Parties");
     public IMongoCollection<Models.Contract> PreviousContracts => Database.GetCollection<Models.Contract>("PreviousContracts");
     public IMongoCollection<Models.Reminder> Reminders => Database.GetCollection<Models.Reminder>("Reminders");

--- a/PaperTrail.Core/Repositories/PartyRepository.cs
+++ b/PaperTrail.Core/Repositories/PartyRepository.cs
@@ -10,17 +10,17 @@ public class PartyRepository : IPartyRepository
     public PartyRepository(MongoContext context) => _context = context;
 
     public Task<List<Party>> GetAllAsync(CancellationToken token = default)
-        => _context.Parties.Find(_ => true).ToListAsync(token);
+        => _context.Clients.Find(_ => true).ToListAsync(token);
 
     public Task<Party?> GetByIdAsync(Guid id, CancellationToken token = default)
-        => _context.Parties.Find(p => p.Id == id).FirstOrDefaultAsync(token);
+        => _context.Clients.Find(p => p.Id == id).FirstOrDefaultAsync(token);
 
     public Task AddAsync(Party party, CancellationToken token = default)
-        => _context.Parties.InsertOneAsync(party, cancellationToken: token);
+        => _context.Clients.InsertOneAsync(party, cancellationToken: token);
 
     public Task UpdateAsync(Party party, CancellationToken token = default)
-        => _context.Parties.ReplaceOneAsync(p => p.Id == party.Id, party, cancellationToken: token);
+        => _context.Clients.ReplaceOneAsync(p => p.Id == party.Id, party, cancellationToken: token);
 
     public Task DeleteAsync(Guid id, CancellationToken token = default)
-        => _context.Parties.DeleteOneAsync(p => p.Id == id, token);
+        => _context.Clients.DeleteOneAsync(p => p.Id == id, token);
 }


### PR DESCRIPTION
## Summary
- refresh imported contract list after adding new contract
- allow selecting or creating clients for contracts, stored in new Clients collection
- add duplicate-and-change feature for imported contracts

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c62ef840288329ad7f20cee24830c2