### PR TITLE
Refresh contract lists when closing and show closed contracts

### DIFF
--- a/PaperTrail.App/Converters/DateTimeToLocalConverter.cs
+++ b/PaperTrail.App/Converters/DateTimeToLocalConverter.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PaperTrail.App.Converters;
+
+public class DateTimeToLocalConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is DateTime dt ? dt.ToLocalTime() : null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is DateTime dt ? dt.ToUniversalTime() : null;
+    }
+}

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -154,4 +154,23 @@ public partial class ContractListViewModel : ObservableObject
         File.WriteAllBytes(file, data);
         MessageBox.Show("Export completed.", "Export", MessageBoxButton.OK, MessageBoxImage.Information);
     }
+
+    public async Task OpenContractAsync(Contract? contract)
+    {
+        if (contract == null)
+            return;
+
+        var model = await _contracts.GetByIdAsync(contract.Id);
+        if (model == null)
+            return;
+
+        var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
+        var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo, _calendar);
+        vm.LoadFromModel(model);
+        var win = new ContractWindow { DataContext = vm };
+        win.ShowDialog();
+        await LoadAsync();
+        var landing = App.Services.GetRequiredService<LandingViewModel>();
+        await landing.LoadAsync();
+    }
 }

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -150,9 +150,11 @@ public partial class LandingViewModel : ObservableObject
         if (contract == null)
             return;
         contract.Status = ContractStatus.Archived;
+        contract.UpdatedUtc = DateTime.UtcNow;
         var repo = isPrevious ? (IContractRepository)_previousRepo : _importedRepo;
         await repo.UpdateAsync(contract);
         await LoadAsync();
+        await _mainViewModel.Contracts.LoadAsync();
     }
 
     public async Task OpenContractAsync(Contract? contract, bool isPrevious)

--- a/PaperTrail.App/Views/ContractListView.xaml
+++ b/PaperTrail.App/Views/ContractListView.xaml
@@ -1,13 +1,18 @@
 <UserControl x:Class="PaperTrail.App.Views.ContractListView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedContract}" AutoGenerateColumns="False">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:PaperTrail.App.Converters">
+    <UserControl.Resources>
+        <conv:DateTimeToLocalConverter x:Key="DateTimeToLocalConverter" />
+    </UserControl.Resources>
+    <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedContract}" AutoGenerateColumns="False" MouseDoubleClick="DataGrid_MouseDoubleClick">
         <DataGrid.Columns>
             <DataGridTextColumn Header="Title" Binding="{Binding Title}" />
             <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" />
             <DataGridTextColumn Header="Status" Binding="{Binding Status}" />
             <DataGridTextColumn Header="Renewal" Binding="{Binding RenewalDate}" />
             <DataGridTextColumn Header="Tags" Binding="{Binding Tags}" />
+            <DataGridTextColumn Header="Closed" Binding="{Binding UpdatedUtc, Converter={StaticResource DateTimeToLocalConverter}}" />
         </DataGrid.Columns>
     </DataGrid>
 </UserControl>

--- a/PaperTrail.App/Views/ContractListView.xaml.cs
+++ b/PaperTrail.App/Views/ContractListView.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using PaperTrail.App.ViewModels;
+
+namespace PaperTrail.App.Views;
+
+public partial class ContractListView : UserControl
+{
+    public ContractListView()
+    {
+        InitializeComponent();
+    }
+
+    private async void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is ContractListViewModel vm)
+        {
+            await vm.OpenContractAsync(vm.SelectedContract);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Refresh all contract lists and record close time when a contract is closed
- Add double-click to open contracts from the list and new column showing closed date
- Provide converter for displaying localized close date

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 and not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c63e3788708329bc072bcdf8128ce5