### PR TITLE
Improve contract listing, search, and editor behaviors

### DIFF
--- a/PaperTrail.App/Converters/BooleanNegationConverter.cs
+++ b/PaperTrail.App/Converters/BooleanNegationConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PaperTrail.App.Converters
+{
+    public class BooleanNegationConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool b)
+            {
+                return !b;
+            }
+            return Binding.DoNothing;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return Convert(value, targetType, parameter, culture);
+        }
+    }
+}

--- a/PaperTrail.App/ViewModels/ContractEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractEditViewModel.cs
@@ -99,6 +99,7 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
 
     [ObservableProperty] private bool hasChanges;
     [ObservableProperty] private bool isPro;
+    [ObservableProperty] private bool isReadOnly;
 
     private string? _computedNextRenewalText;
     public string? ComputedNextRenewalText
@@ -206,14 +207,16 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
 
     // ------------ Loading ------------
 
-    public void LoadFromModel(Contract model)
+    public async Task LoadFromModelAsync(Contract model)
     {
         if (model is null) throw new ArgumentNullException(nameof(model));
 
         Id = model.Id;
         Title = model.Title ?? string.Empty;
 
-        _ = RefreshPartiesAsync(model.Counterparty);
+        await RefreshPartiesAsync(model.Counterparty);
+        if (SelectedParty == null && Parties.Count > 0)
+            SelectedParty = Parties[0];
 
         SelectedStatus = model.Status;
 
@@ -251,7 +254,7 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
 
     // ------------ Validation and change hooks ------------
 
-    private bool CanSave() => !HasErrors;
+    private bool CanSave() => !HasErrors && !IsReadOnly;
 
     private void OnPropertyChangedAndValidate(string propertyName)
     {

--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -88,6 +88,12 @@ public partial class ContractListViewModel : ObservableObject
             Items.Add(c);
     }
 
+    partial void OnSearchTextChanged(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            RefreshCommand.Execute(null);
+    }
+
     private async Task NewAsync()
     {
         var repo = App.Services.GetRequiredService<ICustomContractRepository>();
@@ -107,7 +113,7 @@ public partial class ContractListViewModel : ObservableObject
         await _contracts.AddAsync(contract);
         var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
         var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo, _calendar);
-        vm.LoadFromModel(contract);
+        await vm.LoadFromModelAsync(contract);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
         await LoadAsync();
@@ -134,7 +140,7 @@ public partial class ContractListViewModel : ObservableObject
         {
             var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
             var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo, _calendar);
-            vm.LoadFromModel(model);
+            await vm.LoadFromModelAsync(model);
             var win = new ContractWindow { DataContext = vm };
             win.ShowDialog();
         }
@@ -166,7 +172,8 @@ public partial class ContractListViewModel : ObservableObject
 
         var partyRepo = App.Services.GetRequiredService<IPartyRepository>();
         var vm = new ContractEditViewModel(_contracts, _import, _dialog, _license, partyRepo, _calendar);
-        vm.LoadFromModel(model);
+        vm.IsReadOnly = model.Status == ContractStatus.Archived;
+        await vm.LoadFromModelAsync(model);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
         await LoadAsync();

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -169,7 +169,8 @@ public partial class LandingViewModel : ObservableObject
         await _previousRepo.AddOrUpdateAsync(model);
 
         var vm = new ContractEditViewModel(repo, _importService, _dialogService, _licenseService, _partyRepository, _calendarService);
-        vm.LoadFromModel(model);
+        vm.IsReadOnly = model.Status == ContractStatus.Archived;
+        await vm.LoadFromModelAsync(model);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
         await LoadAsync();
@@ -236,7 +237,7 @@ public partial class LandingViewModel : ObservableObject
         }
 
         var vm = new ContractEditViewModel(_importedRepo, _importService, _dialogService, _licenseService, _partyRepository, _calendarService);
-        vm.LoadFromModel(copy);
+        await vm.LoadFromModelAsync(copy);
         var win = new ContractWindow { DataContext = vm };
         win.ShowDialog();
         await LoadAsync();

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:models="clr-namespace:PaperTrail.Core.Models;assembly=PaperTrail.Core"
+             xmlns:conv="clr-namespace:PaperTrail.App.Converters"
              x:Name="Root"
              AllowDrop="True">
 
@@ -16,9 +17,11 @@
             <Setter Property="BorderBrush" Value="#CBD5E1"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
+
+        <conv:BooleanNegationConverter x:Key="BooleanNegationConverter" />
     </UserControl.Resources>
 
-    <Grid>
+    <Grid IsEnabled="{Binding IsReadOnly, Converter={StaticResource BooleanNegationConverter}}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/PaperTrail.App/Views/ContractListView.xaml
+++ b/PaperTrail.App/Views/ContractListView.xaml
@@ -5,7 +5,7 @@
     <UserControl.Resources>
         <conv:DateTimeToLocalConverter x:Key="DateTimeToLocalConverter" />
     </UserControl.Resources>
-    <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedContract}" AutoGenerateColumns="False" MouseDoubleClick="DataGrid_MouseDoubleClick">
+    <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedContract}" AutoGenerateColumns="False" MouseDoubleClick="DataGrid_MouseDoubleClick" IsReadOnly="True" CanUserAddRows="False">
         <DataGrid.Columns>
             <DataGridTextColumn Header="Title" Binding="{Binding Title}" />
             <DataGridTextColumn Header="Counterparty" Binding="{Binding Counterparty.Name}" />


### PR DESCRIPTION
## Summary
- prevent blank row in contract list grids
- refresh list when search text cleared
- open archived contracts in view-only mode
- load client info for new/edit contracts and allow default selection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c640e6da848329a5019e1ffe1638d5