### PR TITLE
Fix blank contract edit view

### DIFF
--- a/PaperTrail.App/Views/ContractEditView.xaml.cs
+++ b/PaperTrail.App/Views/ContractEditView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace PaperTrail.App.Views;
+
+public partial class ContractEditView : UserControl
+{
+    public ContractEditView()
+    {
+        // Required to load the associated XAML. Without this constructor,
+        // the user control renders blank because InitializeComponent is never called.
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- Add missing code-behind for ContractEditView so InitializeComponent runs and content renders
- Explain why code-behind is required to keep the view from rendering blank

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6463b4f7c8329a77b36f94b5d0710