### PR TITLE
Preserve client selection and enable attachment drag-drop

### DIFF
--- a/PaperTrail.App/ViewModels/ContractEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractEditViewModel.cs
@@ -214,6 +214,10 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
         Id = model.Id;
         Title = model.Title ?? string.Empty;
 
+        // Clear any previous search filter so the stored client is retained
+        partySearchText = string.Empty;
+        OnPropertyChanged(nameof(PartySearchText));
+
         await RefreshPartiesAsync(model.Counterparty);
         if (SelectedParty == null && Parties.Count > 0)
             SelectedParty = Parties[0];
@@ -549,7 +553,8 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
         if (select != null && list.All(p => p.Id != select.Id))
             list.Add(select);
         if (!string.IsNullOrWhiteSpace(PartySearchText))
-            list = list.Where(p => p.Name.Contains(PartySearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+            list = list.Where(p => p.Name.Contains(PartySearchText, StringComparison.OrdinalIgnoreCase)
+                                   || (select != null && p.Id == select.Id)).ToList();
         Parties.Clear();
         foreach (var p in list)
             Parties.Add(p);

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -162,7 +162,7 @@
                     </Grid.RowDefinitions>
 
                     <Border BorderBrush="#CBD5E1" BorderThickness="1" CornerRadius="6" Padding="10" Margin="0,0,0,10"
-                            Background="#F8FAFC">
+                            Background="#F8FAFC" AllowDrop="True" Drop="AttachmentDrop" PreviewDragOver="AttachmentDragOver">
                         <TextBlock Text="Drag files here to attach" HorizontalAlignment="Center"/>
                     </Border>
 

--- a/PaperTrail.App/Views/ContractEditView.xaml.cs
+++ b/PaperTrail.App/Views/ContractEditView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace PaperTrail.App.Views;
@@ -9,5 +10,24 @@ public partial class ContractEditView : UserControl
         // Required to load the associated XAML. Without this constructor,
         // the user control renders blank because InitializeComponent is never called.
         InitializeComponent();
+    }
+
+    private void AttachmentDragOver(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            e.Effects = DragDropEffects.Copy;
+        else
+            e.Effects = DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private async void AttachmentDrop(object sender, DragEventArgs e)
+    {
+        if (DataContext is ViewModels.ContractEditViewModel vm)
+        {
+            var data = e.Data;
+            if (vm.DragDropAttachmentCommand.CanExecute(data))
+                await vm.DragDropAttachmentCommand.ExecuteAsync(data);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure client selection persists by clearing search filters when loading and keeping the selected party in list filters
- Enable dragging files onto the Attachments tab to add them to a contract

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*


------
https://chatgpt.com/codex/tasks/task_e_68c64b31f0748329be2a0009ec0641a0