### PR TITLE
Improve contract duplication and client selection

### DIFF
--- a/PaperTrail.App/ViewModels/ContractListViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractListViewModel.cs
@@ -74,6 +74,9 @@ public partial class ContractListViewModel : ObservableObject
         _dialog = dialog;
         _license = license;
         _calendar = calendar;
+        Statuses = Enum.GetValues<ContractStatus>()
+            .Where(s => s != ContractStatus.Archived)
+            .ToArray();
         RefreshCommand = new AsyncRelayCommand(LoadAsync);
         ImportCommand = new AsyncRelayCommand(ImportAsync);
         ExportCommand = new AsyncRelayCommand(ExportAsync);

--- a/PaperTrail.App/ViewModels/LandingViewModel.cs
+++ b/PaperTrail.App/ViewModels/LandingViewModel.cs
@@ -226,11 +226,25 @@ public partial class LandingViewModel : ObservableObject
                     ContractId = copy.Id,
                     Contract = copy,
                     FileName = att.FileName,
-                    FilePath = att.FilePath,
                     Hash = att.Hash,
                     CreatedUtc = att.CreatedUtc,
                     MissingFile = att.MissingFile
                 };
+
+                if (!string.IsNullOrEmpty(att.FilePath) && File.Exists(att.FilePath))
+                {
+                    var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PaperTrailContractTracker", "files");
+                    Directory.CreateDirectory(baseDir);
+                    var destName = $"{Guid.NewGuid()}_{Path.GetFileName(att.FilePath)}";
+                    var destPath = Path.Combine(baseDir, destName);
+                    File.Copy(att.FilePath, destPath, true);
+                    newAtt.FilePath = destPath;
+                }
+                else
+                {
+                    newAtt.FilePath = att.FilePath;
+                }
+
                 await _importedRepo.AddAttachmentAsync(copy.Id, newAtt);
                 copy.Attachments.Add(newAtt);
             }

--- a/PaperTrail.App/Views/ContractEditView.xaml
+++ b/PaperTrail.App/Views/ContractEditView.xaml
@@ -51,7 +51,11 @@
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="12">
                         <TextBlock Text="Client"/>
-                        <TextBox Text="{Binding PartySearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,4" IsReadOnly="{Binding IsReadOnly}"/>
+                        <TextBox Text="{Binding PartySearchText, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,0,0,4"
+                                 IsReadOnly="{Binding IsReadOnly}"
+                                 IsEnabled="{Binding IsPartySearchEnabled}"
+                                 LostFocus="PartySearch_LostFocus"/>
                         <ComboBox ItemsSource="{Binding Parties}"
                                   SelectedItem="{Binding SelectedParty}"
                                   DisplayMemberPath="Name"

--- a/PaperTrail.App/Views/ContractEditView.xaml.cs
+++ b/PaperTrail.App/Views/ContractEditView.xaml.cs
@@ -30,4 +30,10 @@ public partial class ContractEditView : UserControl
                 await vm.DragDropAttachmentCommand.ExecuteAsync(data);
         }
     }
+
+    private async void PartySearch_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is ViewModels.ContractEditViewModel vm)
+            await vm.EnsurePartySelectedAsync();
+    }
 }

--- a/PaperTrail.App/Views/PartySelectionWindow.xaml
+++ b/PaperTrail.App/Views/PartySelectionWindow.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="PaperTrail.App.Views.PartySelectionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Select Client" Height="300" Width="300"
+        WindowStartupLocation="CenterOwner"
+        Icon="pack://application:,,,/Resources/IconsAndImages/PaperTrailIcon.ico">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ListBox x:Name="PartyList" DisplayMemberPath="Name" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="75" Margin="0,0,10,0" IsDefault="True" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="75" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/PaperTrail.App/Views/PartySelectionWindow.xaml.cs
+++ b/PaperTrail.App/Views/PartySelectionWindow.xaml.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Windows;
+using PaperTrail.Core.Models;
+
+namespace PaperTrail.App.Views;
+
+public partial class PartySelectionWindow : Window
+{
+    public Party? SelectedParty => PartyList.SelectedItem as Party;
+
+    public PartySelectionWindow(IEnumerable<Party> parties)
+    {
+        InitializeComponent();
+        PartyList.ItemsSource = parties;
+    }
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+    }
+}


### PR DESCRIPTION
## Summary
- Hide archived contracts from active views by default
- Enhance client selection with auto-fill and selection dialog
- Copy attachment files when duplicating contracts to avoid missing file errors

## Testing
- `dotnet build PaperTrail.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c64fde15e08329bb298d99d69a41c0