### PR TITLE
Ensure Save closes contract editor and updates client

### DIFF
--- a/PaperTrail.App/ViewModels/ContractEditViewModel.cs
+++ b/PaperTrail.App/ViewModels/ContractEditViewModel.cs
@@ -491,8 +491,18 @@ public partial class ContractEditViewModel : ObservableObject, INotifyDataErrorI
         Reminders.Clear();
         foreach (var r in reminderList)
             Reminders.Add(r);
+        if (SelectedParty != null)
+        {
+            var existing = SelectedParty.Contracts
+                .FirstOrDefault(c => c.Id == model.Id);
+            if (existing != null)
+                SelectedParty.Contracts.Remove(existing);
+            SelectedParty.Contracts.Add(model);
+            await _partyRepository.UpdateAsync(SelectedParty);
+        }
 
         HasChanges = false;
+        CloseWindowForThisVM();
     }
 
     private Contract ToModel()


### PR DESCRIPTION
## Summary
- update contract save logic to sync the contract to the selected client
- close the contract window after successfully saving

## Testing
- `dotnet test` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68c65339d6e08329b120639d29152c06