### PR TITLE
Fix duplicate key errors when saving reminders

### DIFF
--- a/PaperTrail.Core/Repositories/ContractRepository.cs
+++ b/PaperTrail.Core/Repositories/ContractRepository.cs
@@ -97,9 +97,15 @@ public class ContractRepository : IContractRepository
 
     public async Task AddRemindersAsync(Guid contractId, IEnumerable<Reminder> reminders, CancellationToken token = default)
     {
-        foreach (var r in reminders)
+        // Replace existing reminders for the contract to avoid duplicate key errors.
+        var reminderList = reminders.ToList();
+
+        await _context.Reminders.DeleteManyAsync(r => r.ContractId == contractId, token);
+
+        foreach (var r in reminderList)
             r.ContractId = contractId;
-        if (reminders.Any())
-            await _context.Reminders.InsertManyAsync(reminders, cancellationToken: token);
+
+        if (reminderList.Any())
+            await _context.Reminders.InsertManyAsync(reminderList, cancellationToken: token);
     }
 }

--- a/PaperTrail.Core/Repositories/PreviousContractRepository.cs
+++ b/PaperTrail.Core/Repositories/PreviousContractRepository.cs
@@ -122,10 +122,16 @@ public class PreviousContractRepository : IContractRepository
 
     public async Task AddRemindersAsync(Guid contractId, IEnumerable<Reminder> reminders, CancellationToken token = default)
     {
-        foreach (var r in reminders)
+        // Replace any existing reminders for the contract with the provided ones.
+        var reminderList = reminders.ToList();
+
+        await _context.Reminders.DeleteManyAsync(r => r.ContractId == contractId, token);
+
+        foreach (var r in reminderList)
             r.ContractId = contractId;
-        if (reminders.Any())
-            await _context.Reminders.InsertManyAsync(reminders, cancellationToken: token);
+
+        if (reminderList.Any())
+            await _context.Reminders.InsertManyAsync(reminderList, cancellationToken: token);
     }
 }
 


### PR DESCRIPTION
## Summary
- Delete existing reminders for a contract before inserting new ones to avoid duplicate key errors
- Apply replacement logic in both current and previous contract repositories

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c654d1d6d88329b28e20470292ebbb