### PR TITLE
Use cross-platform toast notifications and dedupe reminder IDs

### DIFF
--- a/PaperTrail.App/Services/NotificationService.cs
+++ b/PaperTrail.App/Services/NotificationService.cs
@@ -1,6 +1,5 @@
 using Microsoft.Toolkit.Uwp.Notifications;
 using PaperTrail.Core.Services;
-using Windows.UI.Notifications;
 using System.Windows;
 
 namespace PaperTrail.App.Services;
@@ -9,20 +8,13 @@ public class NotificationService : INotificationService
 {
     public Task ShowAsync(string title, string message)
     {
-        var content = new ToastContentBuilder()
-            .AddText(title)
-            .AddText(message)
-            .GetToastContent();
-
-        // Use ToastNotificationManager for WPF, and marshal to UI thread if needed
+        // Display the toast notification using the toolkit's compatibility layer.
         Application.Current.Dispatcher.Invoke(() =>
         {
-            // Use GetContent() to get the XML string, then load it into an XmlDocument
-            var xmlDoc = new Windows.Data.Xml.Dom.XmlDocument();
-            xmlDoc.LoadXml(content.GetContent());
-            var toast = new ToastNotification(xmlDoc);
-            var notifier = ToastNotificationManager.CreateToastNotifier("PaperTrail.App");
-            notifier.Show(toast);
+            new ToastContentBuilder()
+                .AddText(title)
+                .AddText(message)
+                .Show();
         });
 
         return Task.CompletedTask;

--- a/PaperTrail.Core/Repositories/ContractRepository.cs
+++ b/PaperTrail.Core/Repositories/ContractRepository.cs
@@ -97,15 +97,22 @@ public class ContractRepository : IContractRepository
 
     public async Task AddRemindersAsync(Guid contractId, IEnumerable<Reminder> reminders, CancellationToken token = default)
     {
-        // Replace existing reminders for the contract to avoid duplicate key errors.
-        var reminderList = reminders.ToList();
+        // Replace existing reminders for the contract and ensure no duplicate IDs are inserted.
+        var reminderList = reminders
+            .Select(r =>
+            {
+                if (r.Id == Guid.Empty)
+                    r.Id = Guid.NewGuid();
+                r.ContractId = contractId;
+                return r;
+            })
+            .GroupBy(r => r.Id)
+            .Select(g => g.First())
+            .ToList();
 
         await _context.Reminders.DeleteManyAsync(r => r.ContractId == contractId, token);
 
-        foreach (var r in reminderList)
-            r.ContractId = contractId;
-
-        if (reminderList.Any())
+        if (reminderList.Count > 0)
             await _context.Reminders.InsertManyAsync(reminderList, cancellationToken: token);
     }
 }


### PR DESCRIPTION
## Summary
- avoid unimplemented ToastNotificationManager API by using ToastContentBuilder's Show method
- guard reminder insertions against duplicate MongoDB IDs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c65890f794832986211a7c16afb115