### PR TITLE
fix: prevent circular serialization

### DIFF
--- a/PaperTrail.Core/Models/Contract.cs
+++ b/PaperTrail.Core/Models/Contract.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace PaperTrail.Core.Models;
 
+[BsonIgnoreExtraElements]
 public class Contract
 {
     [Key]
@@ -9,6 +11,7 @@ public class Contract
     [Required]
     public string Title { get; set; } = string.Empty;
     public Guid? CounterpartyId { get; set; }
+    [BsonIgnore]
     public Party? Counterparty { get; set; }
     public ContractStatus Status { get; set; } = ContractStatus.Active;
     public DateOnly? EffectiveDate { get; set; }

--- a/PaperTrail.Core/Models/Party.cs
+++ b/PaperTrail.Core/Models/Party.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace PaperTrail.Core.Models;
 
+[BsonIgnoreExtraElements]
 public class Party
 {
     [Key]
@@ -11,5 +13,6 @@ public class Party
     public string? ContactEmail { get; set; }
     public string? ContactPhone { get; set; }
     public string? Address { get; set; }
+    [BsonIgnore]
     public ICollection<Contract> Contracts { get; set; } = new List<Contract>();
 }


### PR DESCRIPTION
## Summary
- avoid circular serialization issues between Contract and Party models
- ignore extra document fields during deserialization to handle existing data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c65c356e448329b494bf576bcc1081