### PR TITLE
Use environment variable for MongoDB connection string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb://localhost:27017

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vs/
 bin/
 obj/
+.env

--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -31,7 +31,11 @@ public partial class App : Application
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IMongoClient>(_ =>
-                    new MongoClient(Environment.GetEnvironmentVariable("MONGODB_URI") ?? "mongodb+srv://fiwbsolutions:lDQlujC1r9yV0uc4@fiwb-cluster.icshfk2.mongodb.net/"));
+                {
+                    var uri = Environment.GetEnvironmentVariable("MONGODB_URI")
+                        ?? throw new InvalidOperationException("MONGODB_URI environment variable is not set");
+                    return new MongoClient(uri);
+                });
                 services.AddSingleton<MongoContext>();
                 // Use singleton lifetime for repositories so they can be injected into
                 // singleton view models without lifetime conflicts

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ dotnet test
 ## MongoDB
 
 The application stores all data in a MongoDB database named `FIWB-PaperTrail`. The connection string is
-read from the `MONGODB_URI` environment variable and falls back to `mongodb://localhost:27017` when not provided.
+read from the `MONGODB_URI` environment variable. You can set this variable in your shell or by creating a
+`.env` file. See `.env.example` for the expected format.
 Collections in the database are `Attachments`, `ImportedContracts`, `Parties`, `PreviousContracts` and `Reminders`.
 
 ## Features


### PR DESCRIPTION
## Summary
- remove hardcoded MongoDB connection string fallback
- document required MONGODB_URI environment variable and `.env` example

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c696bf9a4c832993b55755e9019b2a