### PR TITLE
Load environment variables from .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example configuration for PaperTrail Contract Tracker
+# Copy this file to .env and adjust values as needed.
+MONGODB_URI=mongodb://localhost:27017

--- a/PaperTrail.App/App.xaml.cs
+++ b/PaperTrail.App/App.xaml.cs
@@ -24,6 +24,8 @@ public partial class App : Application
     {
         base.OnStartup(e);
 
+        LoadEnvFromFile();
+
         var appDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PaperTrailContractTracker");
         Directory.CreateDirectory(Path.Combine(appDir, "files"));
 
@@ -85,6 +87,30 @@ public partial class App : Application
             var settingsVm = new SettingsViewModel(settings);
             var settingsWindow = new SettingsWindow { DataContext = settingsVm, Owner = landingWindow };
             settingsWindow.ShowDialog();
+        }
+    }
+
+    private static void LoadEnvFromFile()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir != null)
+        {
+            var envPath = Path.Combine(dir, ".env");
+            if (File.Exists(envPath))
+            {
+                foreach (var line in File.ReadAllLines(envPath))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
+                        continue;
+
+                    var parts = trimmed.Split('=', 2);
+                    if (parts.Length == 2)
+                        Environment.SetEnvironmentVariable(parts[0].Trim(), parts[1].Trim());
+                }
+                break;
+            }
+            dir = Directory.GetParent(dir)?.FullName;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ dotnet test
 
 The application stores all data in a MongoDB database named `FIWB-PaperTrail`. The connection string is
 read from the `MONGODB_URI` environment variable. You can set this variable in your shell or by creating a
-`.env` file. See `.env.example` for the expected format.
+`.env` file in the project directory. The application will automatically load this file at startup.
+See `.env.example` for the expected format.
 Collections in the database are `Attachments`, `ImportedContracts`, `Parties`, `PreviousContracts` and `Reminders`.
 
 ## Features


### PR DESCRIPTION
## Summary
- Parse a `.env` file at startup so environment variables like `MONGODB_URI` are available without manual export
- Document automatic `.env` loading and add example configuration file

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7265ae6ac8329afe52340cec08f64